### PR TITLE
add date parsing

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -126,21 +126,21 @@ func Parse(text string) (whoisInfo WhoisInfo, err error) { //nolint:cyclop
 			if domain.CreatedDate == "" {
 				domain.CreatedDate = value
 				if parsed, err := parseDateString(value); err == nil {
-					domain.CreatedDateParsed = &parsed
+					domain.CreatedDateInTime = &parsed
 				}
 			}
 		case "updated_date":
 			if domain.UpdatedDate == "" {
 				domain.UpdatedDate = value
 				if parsed, err := parseDateString(value); err == nil {
-					domain.UpdatedDateParsed = &parsed
+					domain.UpdatedDateInTime = &parsed
 				}
 			}
 		case "expired_date":
 			if domain.ExpirationDate == "" {
 				domain.ExpirationDate = value
 				if parsed, err := parseDateString(value); err == nil {
-					domain.ExpirationDateParsed = &parsed
+					domain.ExpirationDateInTime = &parsed
 				}
 			}
 		case "referral_url":

--- a/parser.go
+++ b/parser.go
@@ -125,14 +125,23 @@ func Parse(text string) (whoisInfo WhoisInfo, err error) { //nolint:cyclop
 		case "created_date":
 			if domain.CreatedDate == "" {
 				domain.CreatedDate = value
+				if parsed, err := parseDateString(value); err == nil {
+					domain.CreatedDateParsed = &parsed
+				}
 			}
 		case "updated_date":
 			if domain.UpdatedDate == "" {
 				domain.UpdatedDate = value
+				if parsed, err := parseDateString(value); err == nil {
+					domain.UpdatedDateParsed = &parsed
+				}
 			}
 		case "expired_date":
 			if domain.ExpirationDate == "" {
 				domain.ExpirationDate = value
+				if parsed, err := parseDateString(value); err == nil {
+					domain.ExpirationDateParsed = &parsed
+				}
 			}
 		case "referral_url":
 			registrar.ReferralURL = value

--- a/parser_test.go
+++ b/parser_test.go
@@ -141,16 +141,19 @@ func TestParse(t *testing.T) {
 		if !assert.IsContains([]string{"aq", "au", "de", "eu", "gov", "hm", "name", "nl", "nz", "ir", "tk",
 			"xn--mgba3a4f16a"}, extension) {
 			assert.NotZero(t, whoisInfo.Domain.CreatedDate)
+			assert.NotNil(t, whoisInfo.Domain.CreatedDateParsed)
 		}
 
 		if !assert.IsContains([]string{"aq", "ch", "cn", "eu", "gov", "hk", "hm", "mo",
 			"name", "nl", "ro", "ru", "su", "tk", "tw", "xn--fiqs8s", "xn--p1ai"}, extension) {
 			assert.NotZero(t, whoisInfo.Domain.UpdatedDate)
+			assert.NotNil(t, whoisInfo.Domain.UpdatedDateParsed)
 		}
 
 		if !assert.IsContains([]string{"", "aq", "au", "br", "ch", "de", "eu", "gov", "ee",
 			"hm", "int", "name", "nl", "nz", "tk", "kz"}, extension) {
 			assert.NotZero(t, whoisInfo.Domain.ExpirationDate)
+			assert.NotNil(t, whoisInfo.Domain.ExpirationDateParsed)
 		}
 
 		if !assert.IsContains([]string{"", "ai", "aq", "au", "br", "ca", "ch", "cn", "cx", "de",

--- a/parser_test.go
+++ b/parser_test.go
@@ -141,19 +141,19 @@ func TestParse(t *testing.T) {
 		if !assert.IsContains([]string{"aq", "au", "de", "eu", "gov", "hm", "name", "nl", "nz", "ir", "tk",
 			"xn--mgba3a4f16a"}, extension) {
 			assert.NotZero(t, whoisInfo.Domain.CreatedDate)
-			assert.NotNil(t, whoisInfo.Domain.CreatedDateParsed)
+			assert.NotNil(t, whoisInfo.Domain.CreatedDateInTime)
 		}
 
 		if !assert.IsContains([]string{"aq", "ch", "cn", "eu", "gov", "hk", "hm", "mo",
 			"name", "nl", "ro", "ru", "su", "tk", "tw", "xn--fiqs8s", "xn--p1ai"}, extension) {
 			assert.NotZero(t, whoisInfo.Domain.UpdatedDate)
-			assert.NotNil(t, whoisInfo.Domain.UpdatedDateParsed)
+			assert.NotNil(t, whoisInfo.Domain.UpdatedDateInTime)
 		}
 
 		if !assert.IsContains([]string{"", "aq", "au", "br", "ch", "de", "eu", "gov", "ee",
 			"hm", "int", "name", "nl", "nz", "tk", "kz"}, extension) {
 			assert.NotZero(t, whoisInfo.Domain.ExpirationDate)
-			assert.NotNil(t, whoisInfo.Domain.ExpirationDateParsed)
+			assert.NotNil(t, whoisInfo.Domain.ExpirationDateInTime)
 		}
 
 		if !assert.IsContains([]string{"", "ai", "aq", "au", "br", "ca", "ch", "cn", "cx", "de",

--- a/struct.go
+++ b/struct.go
@@ -19,6 +19,8 @@
 
 package whoisparser
 
+import "time"
+
 // WhoisInfo storing domain whois info
 type WhoisInfo struct {
 	Domain         *Domain  `json:"domain,omitempty"`
@@ -31,18 +33,21 @@ type WhoisInfo struct {
 
 // Domain storing domain name info
 type Domain struct {
-	ID             string   `json:"id,omitempty"`
-	Domain         string   `json:"domain,omitempty"`
-	Punycode       string   `json:"punycode,omitempty"`
-	Name           string   `json:"name,omitempty"`
-	Extension      string   `json:"extension,omitempty"`
-	WhoisServer    string   `json:"whois_server,omitempty"`
-	Status         []string `json:"status,omitempty"`
-	NameServers    []string `json:"name_servers,omitempty"`
-	DNSSec         bool     `json:"dnssec,omitempty"`
-	CreatedDate    string   `json:"created_date,omitempty"`
-	UpdatedDate    string   `json:"updated_date,omitempty"`
-	ExpirationDate string   `json:"expiration_date,omitempty"`
+	ID                   string     `json:"id,omitempty"`
+	Domain               string     `json:"domain,omitempty"`
+	Punycode             string     `json:"punycode,omitempty"`
+	Name                 string     `json:"name,omitempty"`
+	Extension            string     `json:"extension,omitempty"`
+	WhoisServer          string     `json:"whois_server,omitempty"`
+	Status               []string   `json:"status,omitempty"`
+	NameServers          []string   `json:"name_servers,omitempty"`
+	DNSSec               bool       `json:"dnssec,omitempty"`
+	CreatedDate          string     `json:"created_date,omitempty"`
+	CreatedDateParsed    *time.Time `json:"created_date_parsed,omitempty"`
+	UpdatedDate          string     `json:"updated_date,omitempty"`
+	UpdatedDateParsed    *time.Time `json:"updated_date_parsed,omitempty"`
+	ExpirationDate       string     `json:"expiration_date,omitempty"`
+	ExpirationDateParsed *time.Time `json:"expiration_date_parsed,omitempty"`
 }
 
 // Contact storing domain contact info

--- a/struct.go
+++ b/struct.go
@@ -43,11 +43,11 @@ type Domain struct {
 	NameServers          []string   `json:"name_servers,omitempty"`
 	DNSSec               bool       `json:"dnssec,omitempty"`
 	CreatedDate          string     `json:"created_date,omitempty"`
-	CreatedDateParsed    *time.Time `json:"created_date_parsed,omitempty"`
+	CreatedDateInTime    *time.Time `json:"created_date_in_time,omitempty"`
 	UpdatedDate          string     `json:"updated_date,omitempty"`
-	UpdatedDateParsed    *time.Time `json:"updated_date_parsed,omitempty"`
+	UpdatedDateInTime    *time.Time `json:"updated_date_in_time,omitempty"`
 	ExpirationDate       string     `json:"expiration_date,omitempty"`
-	ExpirationDateParsed *time.Time `json:"expiration_date_parsed,omitempty"`
+	ExpirationDateInTime *time.Time `json:"expiration_date_in_time,omitempty"`
 }
 
 // Contact storing domain contact info

--- a/testdata/noterror/ac_git.ac.json
+++ b/testdata/noterror/ac_git.ac.json
@@ -16,11 +16,11 @@
             "f1g1ns1.dnspod.net"
         ],
         "created_date": "2018-02-09 11:59:43",
-        "created_date_parsed": "2018-02-09T11:59:43Z",
+        "created_date_in_time": "2018-02-09T11:59:43Z",
         "updated_date": "2018-12-10 01:00:04",
-        "updated_date_parsed": "2018-12-10T01:00:04Z",
+        "updated_date_in_time": "2018-12-10T01:00:04Z",
         "expiration_date": "2020-02-09 11:59:43",
-        "expiration_date_parsed": "2020-02-09T11:59:43Z"
+        "expiration_date_in_time": "2020-02-09T11:59:43Z"
     },
     "registrar": {
         "id": "1861",

--- a/testdata/noterror/ac_git.ac.json
+++ b/testdata/noterror/ac_git.ac.json
@@ -16,8 +16,11 @@
             "f1g1ns1.dnspod.net"
         ],
         "created_date": "2018-02-09 11:59:43",
+        "created_date_parsed": "2018-02-09T11:59:43Z",
         "updated_date": "2018-12-10 01:00:04",
-        "expiration_date": "2020-02-09 11:59:43"
+        "updated_date_parsed": "2018-12-10T01:00:04Z",
+        "expiration_date": "2020-02-09 11:59:43",
+        "expiration_date_parsed": "2020-02-09T11:59:43Z"
     },
     "registrar": {
         "id": "1861",

--- a/testdata/noterror/aero_google.aero.json
+++ b/testdata/noterror/aero_google.aero.json
@@ -13,8 +13,11 @@
             "ns1.hosting.reg.ru"
         ],
         "created_date": "2019-08-04T11:35:07Z",
+        "created_date_parsed": "2019-08-04T11:35:07Z",
         "updated_date": "2019-10-04T05:05:04Z",
-        "expiration_date": "2020-08-04T11:35:07Z"
+        "updated_date_parsed": "2019-10-04T05:05:04Z",
+        "expiration_date": "2020-08-04T11:35:07Z",
+        "expiration_date_parsed": "2020-08-04T11:35:07Z"
     },
     "registrar": {
         "id": "85",

--- a/testdata/noterror/aero_google.aero.json
+++ b/testdata/noterror/aero_google.aero.json
@@ -13,11 +13,11 @@
             "ns1.hosting.reg.ru"
         ],
         "created_date": "2019-08-04T11:35:07Z",
-        "created_date_parsed": "2019-08-04T11:35:07Z",
+        "created_date_in_time": "2019-08-04T11:35:07Z",
         "updated_date": "2019-10-04T05:05:04Z",
-        "updated_date_parsed": "2019-10-04T05:05:04Z",
+        "updated_date_in_time": "2019-10-04T05:05:04Z",
         "expiration_date": "2020-08-04T11:35:07Z",
-        "expiration_date_parsed": "2020-08-04T11:35:07Z"
+        "expiration_date_in_time": "2020-08-04T11:35:07Z"
     },
     "registrar": {
         "id": "85",

--- a/testdata/noterror/aero_vas.aero.json
+++ b/testdata/noterror/aero_vas.aero.json
@@ -13,8 +13,11 @@
             "ns1.jax.peak-10.com"
         ],
         "created_date": "2010-07-07T19:23:48Z",
+        "created_date_parsed": "2010-07-07T19:23:48Z",
         "updated_date": "2018-06-29T00:13:29Z",
-        "expiration_date": "2021-07-07T19:23:48Z"
+        "updated_date_parsed": "2018-06-29T00:13:29Z",
+        "expiration_date": "2021-07-07T19:23:48Z",
+        "expiration_date_parsed": "2021-07-07T19:23:48Z"
     },
     "registrar": {
         "id": "1011",

--- a/testdata/noterror/aero_vas.aero.json
+++ b/testdata/noterror/aero_vas.aero.json
@@ -13,11 +13,11 @@
             "ns1.jax.peak-10.com"
         ],
         "created_date": "2010-07-07T19:23:48Z",
-        "created_date_parsed": "2010-07-07T19:23:48Z",
+        "created_date_in_time": "2010-07-07T19:23:48Z",
         "updated_date": "2018-06-29T00:13:29Z",
-        "updated_date_parsed": "2018-06-29T00:13:29Z",
+        "updated_date_in_time": "2018-06-29T00:13:29Z",
         "expiration_date": "2021-07-07T19:23:48Z",
-        "expiration_date_parsed": "2021-07-07T19:23:48Z"
+        "expiration_date_in_time": "2021-07-07T19:23:48Z"
     },
     "registrar": {
         "id": "1011",

--- a/testdata/noterror/ai_git.ai.json
+++ b/testdata/noterror/ai_git.ai.json
@@ -14,11 +14,11 @@
             "ns1.onlydomains.com"
         ],
         "created_date": "2017-12-16T03:58:55.24Z",
-        "created_date_parsed": "2017-12-16T03:58:55.24Z",
+        "created_date_in_time": "2017-12-16T03:58:55.24Z",
         "updated_date": "2018-02-27T17:13:41.976Z",
-        "updated_date_parsed": "2018-02-27T17:13:41.976Z",
+        "updated_date_in_time": "2018-02-27T17:13:41.976Z",
         "expiration_date": "2020-02-28T03:58:55.78Z",
-        "expiration_date_parsed": "2020-02-28T03:58:55.78Z"
+        "expiration_date_in_time": "2020-02-28T03:58:55.78Z"
     },
     "registrar": {
         "name": "Instra"

--- a/testdata/noterror/ai_git.ai.json
+++ b/testdata/noterror/ai_git.ai.json
@@ -14,8 +14,11 @@
             "ns1.onlydomains.com"
         ],
         "created_date": "2017-12-16T03:58:55.24Z",
+        "created_date_parsed": "2017-12-16T03:58:55.24Z",
         "updated_date": "2018-02-27T17:13:41.976Z",
-        "expiration_date": "2020-02-28T03:58:55.78Z"
+        "updated_date_parsed": "2018-02-27T17:13:41.976Z",
+        "expiration_date": "2020-02-28T03:58:55.78Z",
+        "expiration_date_parsed": "2020-02-28T03:58:55.78Z"
     },
     "registrar": {
         "name": "Instra"

--- a/testdata/noterror/ai_google.ai.json
+++ b/testdata/noterror/ai_google.ai.json
@@ -18,11 +18,11 @@
             "ns2.zdns.google"
         ],
         "created_date": "2017-12-16T05:37:20.801Z",
-        "created_date_parsed": "2017-12-16T05:37:20.801Z",
+        "created_date_in_time": "2017-12-16T05:37:20.801Z",
         "updated_date": "2019-08-24T09:32:27.549Z",
-        "updated_date_parsed": "2019-08-24T09:32:27.549Z",
+        "updated_date_in_time": "2019-08-24T09:32:27.549Z",
         "expiration_date": "2021-09-25T05:37:20.856Z",
-        "expiration_date_parsed": "2021-09-25T05:37:20.856Z"
+        "expiration_date_in_time": "2021-09-25T05:37:20.856Z"
     },
     "registrar": {
         "name": "Markmonitor",

--- a/testdata/noterror/ai_google.ai.json
+++ b/testdata/noterror/ai_google.ai.json
@@ -18,8 +18,11 @@
             "ns2.zdns.google"
         ],
         "created_date": "2017-12-16T05:37:20.801Z",
+        "created_date_parsed": "2017-12-16T05:37:20.801Z",
         "updated_date": "2019-08-24T09:32:27.549Z",
-        "expiration_date": "2021-09-25T05:37:20.856Z"
+        "updated_date_parsed": "2019-08-24T09:32:27.549Z",
+        "expiration_date": "2021-09-25T05:37:20.856Z",
+        "expiration_date_parsed": "2021-09-25T05:37:20.856Z"
     },
     "registrar": {
         "name": "Markmonitor",

--- a/testdata/noterror/asia_git.asia.json
+++ b/testdata/noterror/asia_git.asia.json
@@ -15,8 +15,11 @@
             "ns3.dnsowl.com"
         ],
         "created_date": "2018-09-27T13:26:20Z",
+        "created_date_parsed": "2018-09-27T13:26:20Z",
         "updated_date": "2019-09-27T22:24:16Z",
-        "expiration_date": "2020-09-27T13:26:20Z"
+        "updated_date_parsed": "2019-09-27T22:24:16Z",
+        "expiration_date": "2020-09-27T13:26:20Z",
+        "expiration_date_parsed": "2020-09-27T13:26:20Z"
     },
     "registrar": {
         "id": "1479",

--- a/testdata/noterror/asia_git.asia.json
+++ b/testdata/noterror/asia_git.asia.json
@@ -15,11 +15,11 @@
             "ns3.dnsowl.com"
         ],
         "created_date": "2018-09-27T13:26:20Z",
-        "created_date_parsed": "2018-09-27T13:26:20Z",
+        "created_date_in_time": "2018-09-27T13:26:20Z",
         "updated_date": "2019-09-27T22:24:16Z",
-        "updated_date_parsed": "2019-09-27T22:24:16Z",
+        "updated_date_in_time": "2019-09-27T22:24:16Z",
         "expiration_date": "2020-09-27T13:26:20Z",
-        "expiration_date_parsed": "2020-09-27T13:26:20Z"
+        "expiration_date_in_time": "2020-09-27T13:26:20Z"
     },
     "registrar": {
         "id": "1479",

--- a/testdata/noterror/asia_google.asia.json
+++ b/testdata/noterror/asia_google.asia.json
@@ -17,11 +17,11 @@
             "ns4.googledomains.com"
         ],
         "created_date": "2007-11-21T20:47:29Z",
-        "created_date_parsed": "2007-11-21T20:47:29Z",
+        "created_date_in_time": "2007-11-21T20:47:29Z",
         "updated_date": "2018-10-20T09:32:07Z",
-        "updated_date_parsed": "2018-10-20T09:32:07Z",
+        "updated_date_in_time": "2018-10-20T09:32:07Z",
         "expiration_date": "2019-11-21T20:47:29Z",
-        "expiration_date_parsed": "2019-11-21T20:47:29Z"
+        "expiration_date_in_time": "2019-11-21T20:47:29Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/asia_google.asia.json
+++ b/testdata/noterror/asia_google.asia.json
@@ -17,8 +17,11 @@
             "ns4.googledomains.com"
         ],
         "created_date": "2007-11-21T20:47:29Z",
+        "created_date_parsed": "2007-11-21T20:47:29Z",
         "updated_date": "2018-10-20T09:32:07Z",
-        "expiration_date": "2019-11-21T20:47:29Z"
+        "updated_date_parsed": "2018-10-20T09:32:07Z",
+        "expiration_date": "2019-11-21T20:47:29Z",
+        "expiration_date_parsed": "2019-11-21T20:47:29Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/au_acma.gov.au.json
+++ b/testdata/noterror/au_acma.gov.au.json
@@ -16,7 +16,7 @@
             "dns3.sge.net"
         ],
         "updated_date": "2019-04-06T22:20:08Z",
-        "updated_date_parsed": "2019-04-06T22:20:08Z"
+        "updated_date_in_time": "2019-04-06T22:20:08Z"
     },
     "registrar": {
         "name": "Digital Transformation Agency",

--- a/testdata/noterror/au_acma.gov.au.json
+++ b/testdata/noterror/au_acma.gov.au.json
@@ -15,7 +15,8 @@
             "dns1.sge.net",
             "dns3.sge.net"
         ],
-        "updated_date": "2019-04-06T22:20:08Z"
+        "updated_date": "2019-04-06T22:20:08Z",
+        "updated_date_parsed": "2019-04-06T22:20:08Z"
     },
     "registrar": {
         "name": "Digital Transformation Agency",

--- a/testdata/noterror/au_google.com.au.json
+++ b/testdata/noterror/au_google.com.au.json
@@ -19,7 +19,8 @@
             "ns3.google.com",
             "ns4.google.com"
         ],
-        "updated_date": "2019-04-17T19:49:19Z"
+        "updated_date": "2019-04-17T19:49:19Z",
+        "updated_date_parsed": "2019-04-17T19:49:19Z"
     },
     "registrar": {
         "name": "MarkMonitor Corporate Services Inc"

--- a/testdata/noterror/au_google.com.au.json
+++ b/testdata/noterror/au_google.com.au.json
@@ -20,7 +20,7 @@
             "ns4.google.com"
         ],
         "updated_date": "2019-04-17T19:49:19Z",
-        "updated_date_parsed": "2019-04-17T19:49:19Z"
+        "updated_date_in_time": "2019-04-17T19:49:19Z"
     },
     "registrar": {
         "name": "MarkMonitor Corporate Services Inc"

--- a/testdata/noterror/berlin_google.berlin.json
+++ b/testdata/noterror/berlin_google.berlin.json
@@ -17,11 +17,11 @@
             "ns4.googledomains.com"
         ],
         "created_date": "2014-02-15T20:24:48Z",
-        "created_date_parsed": "2014-02-15T20:24:48Z",
+        "created_date_in_time": "2014-02-15T20:24:48Z",
         "updated_date": "2019-01-14T10:32:15Z",
-        "updated_date_parsed": "2019-01-14T10:32:15Z",
+        "updated_date_in_time": "2019-01-14T10:32:15Z",
         "expiration_date": "2020-02-15T20:24:48Z",
-        "expiration_date_parsed": "2020-02-15T20:24:48Z"
+        "expiration_date_in_time": "2020-02-15T20:24:48Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/berlin_google.berlin.json
+++ b/testdata/noterror/berlin_google.berlin.json
@@ -17,8 +17,11 @@
             "ns4.googledomains.com"
         ],
         "created_date": "2014-02-15T20:24:48Z",
+        "created_date_parsed": "2014-02-15T20:24:48Z",
         "updated_date": "2019-01-14T10:32:15Z",
-        "expiration_date": "2020-02-15T20:24:48Z"
+        "updated_date_parsed": "2019-01-14T10:32:15Z",
+        "expiration_date": "2020-02-15T20:24:48Z",
+        "expiration_date_parsed": "2020-02-15T20:24:48Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/berlin_toa.berlin.json
+++ b/testdata/noterror/berlin_toa.berlin.json
@@ -15,8 +15,11 @@
             "ns-903.awsdns-48.net"
         ],
         "created_date": "2014-06-16T19:42:59Z",
+        "created_date_parsed": "2014-06-16T19:42:59Z",
         "updated_date": "2017-01-24T23:11:12Z",
-        "expiration_date": "2020-06-16T19:42:59Z"
+        "updated_date_parsed": "2017-01-24T23:11:12Z",
+        "expiration_date": "2020-06-16T19:42:59Z",
+        "expiration_date_parsed": "2020-06-16T19:42:59Z"
     },
     "registrar": {
         "id": "1420",

--- a/testdata/noterror/berlin_toa.berlin.json
+++ b/testdata/noterror/berlin_toa.berlin.json
@@ -15,11 +15,11 @@
             "ns-903.awsdns-48.net"
         ],
         "created_date": "2014-06-16T19:42:59Z",
-        "created_date_parsed": "2014-06-16T19:42:59Z",
+        "created_date_in_time": "2014-06-16T19:42:59Z",
         "updated_date": "2017-01-24T23:11:12Z",
-        "updated_date_parsed": "2017-01-24T23:11:12Z",
+        "updated_date_in_time": "2017-01-24T23:11:12Z",
         "expiration_date": "2020-06-16T19:42:59Z",
-        "expiration_date_parsed": "2020-06-16T19:42:59Z"
+        "expiration_date_in_time": "2020-06-16T19:42:59Z"
     },
     "registrar": {
         "id": "1420",

--- a/testdata/noterror/biz_github.biz.json
+++ b/testdata/noterror/biz_github.biz.json
@@ -17,8 +17,11 @@
             "ns4.p16.dynect.net"
         ],
         "created_date": "2010-08-05T17:04:27Z",
+        "created_date_parsed": "2010-08-05T17:04:27Z",
         "updated_date": "2018-10-21T11:00:23Z",
-        "expiration_date": "2020-08-04T23:59:59Z"
+        "updated_date_parsed": "2018-10-21T11:00:23Z",
+        "expiration_date": "2020-08-04T23:59:59Z",
+        "expiration_date_parsed": "2020-08-04T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/biz_github.biz.json
+++ b/testdata/noterror/biz_github.biz.json
@@ -17,11 +17,11 @@
             "ns4.p16.dynect.net"
         ],
         "created_date": "2010-08-05T17:04:27Z",
-        "created_date_parsed": "2010-08-05T17:04:27Z",
+        "created_date_in_time": "2010-08-05T17:04:27Z",
         "updated_date": "2018-10-21T11:00:23Z",
-        "updated_date_parsed": "2018-10-21T11:00:23Z",
+        "updated_date_in_time": "2018-10-21T11:00:23Z",
         "expiration_date": "2020-08-04T23:59:59Z",
-        "expiration_date_parsed": "2020-08-04T23:59:59Z"
+        "expiration_date_in_time": "2020-08-04T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/biz_google.biz.json
+++ b/testdata/noterror/biz_google.biz.json
@@ -17,8 +17,11 @@
             "ns3.google.com"
         ],
         "created_date": "2002-03-27T16:03:44Z",
+        "created_date_parsed": "2002-03-27T16:03:44Z",
         "updated_date": "2019-02-27T10:56:14Z",
-        "expiration_date": "2020-03-26T23:59:59Z"
+        "updated_date_parsed": "2019-02-27T10:56:14Z",
+        "expiration_date": "2020-03-26T23:59:59Z",
+        "expiration_date_parsed": "2020-03-26T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/biz_google.biz.json
+++ b/testdata/noterror/biz_google.biz.json
@@ -17,11 +17,11 @@
             "ns3.google.com"
         ],
         "created_date": "2002-03-27T16:03:44Z",
-        "created_date_parsed": "2002-03-27T16:03:44Z",
+        "created_date_in_time": "2002-03-27T16:03:44Z",
         "updated_date": "2019-02-27T10:56:14Z",
-        "updated_date_parsed": "2019-02-27T10:56:14Z",
+        "updated_date_in_time": "2019-02-27T10:56:14Z",
         "expiration_date": "2020-03-26T23:59:59Z",
-        "expiration_date_parsed": "2020-03-26T23:59:59Z"
+        "expiration_date_in_time": "2020-03-26T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/ca_git.ca.json
+++ b/testdata/noterror/ca_git.ca.json
@@ -16,11 +16,11 @@
             "pdns10.domaincontrol.com"
         ],
         "created_date": "2003-07-11T15:52:06Z",
-        "created_date_parsed": "2003-07-11T15:52:06Z",
+        "created_date_in_time": "2003-07-11T15:52:06Z",
         "updated_date": "2017-04-07T16:59:35Z",
-        "updated_date_parsed": "2017-04-07T16:59:35Z",
+        "updated_date_in_time": "2017-04-07T16:59:35Z",
         "expiration_date": "2026-07-08T04:00:00Z",
-        "expiration_date_parsed": "2026-07-08T04:00:00Z"
+        "expiration_date_in_time": "2026-07-08T04:00:00Z"
     },
     "registrar": {
         "name": "Go Daddy Domains Canada, Inc",

--- a/testdata/noterror/ca_git.ca.json
+++ b/testdata/noterror/ca_git.ca.json
@@ -16,8 +16,11 @@
             "pdns10.domaincontrol.com"
         ],
         "created_date": "2003-07-11T15:52:06Z",
+        "created_date_parsed": "2003-07-11T15:52:06Z",
         "updated_date": "2017-04-07T16:59:35Z",
-        "expiration_date": "2026-07-08T04:00:00Z"
+        "updated_date_parsed": "2017-04-07T16:59:35Z",
+        "expiration_date": "2026-07-08T04:00:00Z",
+        "expiration_date_parsed": "2026-07-08T04:00:00Z"
     },
     "registrar": {
         "name": "Go Daddy Domains Canada, Inc",

--- a/testdata/noterror/ca_google.ca.json
+++ b/testdata/noterror/ca_google.ca.json
@@ -21,11 +21,11 @@
             "ns4.google.com"
         ],
         "created_date": "2000-10-04T02:21:23Z",
-        "created_date_parsed": "2000-10-04T02:21:23Z",
+        "created_date_in_time": "2000-10-04T02:21:23Z",
         "updated_date": "2019-04-28T04:04:23Z",
-        "updated_date_parsed": "2019-04-28T04:04:23Z",
+        "updated_date_in_time": "2019-04-28T04:04:23Z",
         "expiration_date": "2020-04-28T04:00:00Z",
-        "expiration_date_parsed": "2020-04-28T04:00:00Z"
+        "expiration_date_in_time": "2020-04-28T04:00:00Z"
     },
     "registrar": {
         "name": "MarkMonitor International Canada Ltd.",

--- a/testdata/noterror/ca_google.ca.json
+++ b/testdata/noterror/ca_google.ca.json
@@ -21,8 +21,11 @@
             "ns4.google.com"
         ],
         "created_date": "2000-10-04T02:21:23Z",
+        "created_date_parsed": "2000-10-04T02:21:23Z",
         "updated_date": "2019-04-28T04:04:23Z",
-        "expiration_date": "2020-04-28T04:00:00Z"
+        "updated_date_parsed": "2019-04-28T04:04:23Z",
+        "expiration_date": "2020-04-28T04:00:00Z",
+        "expiration_date_parsed": "2020-04-28T04:00:00Z"
     },
     "registrar": {
         "name": "MarkMonitor International Canada Ltd.",

--- a/testdata/noterror/cat_git.cat.json
+++ b/testdata/noterror/cat_git.cat.json
@@ -14,8 +14,11 @@
             "ns2.smartgslb.com"
         ],
         "created_date": "2018-11-17T16:11:05Z",
+        "created_date_parsed": "2018-11-17T16:11:05Z",
         "updated_date": "2019-09-18T15:20:27Z",
-        "expiration_date": "2019-11-17T16:11:05Z"
+        "updated_date_parsed": "2019-09-18T15:20:27Z",
+        "expiration_date": "2019-11-17T16:11:05Z",
+        "expiration_date_parsed": "2019-11-17T16:11:05Z"
     },
     "registrar": {
         "id": "81",

--- a/testdata/noterror/cat_git.cat.json
+++ b/testdata/noterror/cat_git.cat.json
@@ -14,11 +14,11 @@
             "ns2.smartgslb.com"
         ],
         "created_date": "2018-11-17T16:11:05Z",
-        "created_date_parsed": "2018-11-17T16:11:05Z",
+        "created_date_in_time": "2018-11-17T16:11:05Z",
         "updated_date": "2019-09-18T15:20:27Z",
-        "updated_date_parsed": "2019-09-18T15:20:27Z",
+        "updated_date_in_time": "2019-09-18T15:20:27Z",
         "expiration_date": "2019-11-17T16:11:05Z",
-        "expiration_date_parsed": "2019-11-17T16:11:05Z"
+        "expiration_date_in_time": "2019-11-17T16:11:05Z"
     },
     "registrar": {
         "id": "81",

--- a/testdata/noterror/cc_msn.cc.json
+++ b/testdata/noterror/cc_msn.cc.json
@@ -16,11 +16,11 @@
             "ns1.msft.net"
         ],
         "created_date": "1997-10-12T00:00:00Z",
-        "created_date_parsed": "1997-10-12T00:00:00Z",
+        "created_date_in_time": "1997-10-12T00:00:00Z",
         "updated_date": "2019-09-10T01:00:17Z",
-        "updated_date_parsed": "2019-09-10T01:00:17Z",
+        "updated_date_in_time": "2019-09-10T01:00:17Z",
         "expiration_date": "2020-10-12T04:00:00Z",
-        "expiration_date_parsed": "2020-10-12T04:00:00Z"
+        "expiration_date_in_time": "2020-10-12T04:00:00Z"
     },
     "registrar": {
         "id": "299",

--- a/testdata/noterror/cc_msn.cc.json
+++ b/testdata/noterror/cc_msn.cc.json
@@ -16,8 +16,11 @@
             "ns1.msft.net"
         ],
         "created_date": "1997-10-12T00:00:00Z",
+        "created_date_parsed": "1997-10-12T00:00:00Z",
         "updated_date": "2019-09-10T01:00:17Z",
-        "expiration_date": "2020-10-12T04:00:00Z"
+        "updated_date_parsed": "2019-09-10T01:00:17Z",
+        "expiration_date": "2020-10-12T04:00:00Z",
+        "expiration_date_parsed": "2020-10-12T04:00:00Z"
     },
     "registrar": {
         "id": "299",

--- a/testdata/noterror/cn_apple.cn.json
+++ b/testdata/noterror/cn_apple.cn.json
@@ -18,9 +18,9 @@
             "d.ns.apple.com"
         ],
         "created_date": "2003-03-17 12:20:05",
-        "created_date_parsed": "2003-03-17T12:20:05Z",
+        "created_date_in_time": "2003-03-17T12:20:05Z",
         "expiration_date": "2020-03-17 12:48:36",
-        "expiration_date_parsed": "2020-03-17T12:48:36Z"
+        "expiration_date_in_time": "2020-03-17T12:48:36Z"
     },
     "registrar": {
         "name": "Corporation Service Company"

--- a/testdata/noterror/cn_apple.cn.json
+++ b/testdata/noterror/cn_apple.cn.json
@@ -18,7 +18,9 @@
             "d.ns.apple.com"
         ],
         "created_date": "2003-03-17 12:20:05",
-        "expiration_date": "2020-03-17 12:48:36"
+        "created_date_parsed": "2003-03-17T12:20:05Z",
+        "expiration_date": "2020-03-17 12:48:36",
+        "expiration_date_parsed": "2020-03-17T12:48:36Z"
     },
     "registrar": {
         "name": "Corporation Service Company"

--- a/testdata/noterror/cn_cn.json
+++ b/testdata/noterror/cn_cn.json
@@ -18,7 +18,9 @@
             "ns.cernet.net"
         ],
         "created_date": "1990-11-28",
-        "updated_date": "2018-03-01"
+        "created_date_parsed": "1990-11-28T00:00:00Z",
+        "updated_date": "2018-03-01",
+        "updated_date_parsed": "2018-03-01T00:00:00Z"
     },
     "registrant": {
         "organization": "China Internet Network Information Center (CNNIC)",

--- a/testdata/noterror/cn_cn.json
+++ b/testdata/noterror/cn_cn.json
@@ -18,9 +18,9 @@
             "ns.cernet.net"
         ],
         "created_date": "1990-11-28",
-        "created_date_parsed": "1990-11-28T00:00:00Z",
+        "created_date_in_time": "1990-11-28T00:00:00Z",
         "updated_date": "2018-03-01",
-        "updated_date_parsed": "2018-03-01T00:00:00Z"
+        "updated_date_in_time": "2018-03-01T00:00:00Z"
     },
     "registrant": {
         "organization": "China Internet Network Information Center (CNNIC)",

--- a/testdata/noterror/cn_google.cn.json
+++ b/testdata/noterror/cn_google.cn.json
@@ -19,9 +19,9 @@
             "ns4.google.com"
         ],
         "created_date": "2003-03-17 12:20:05",
-        "created_date_parsed": "2003-03-17T12:20:05Z",
+        "created_date_in_time": "2003-03-17T12:20:05Z",
         "expiration_date": "2021-03-17 12:48:36",
-        "expiration_date_parsed": "2021-03-17T12:48:36Z"
+        "expiration_date_in_time": "2021-03-17T12:48:36Z"
     },
     "registrar": {
         "name": "厦门易名科技股份有限公司"

--- a/testdata/noterror/cn_google.cn.json
+++ b/testdata/noterror/cn_google.cn.json
@@ -19,7 +19,9 @@
             "ns4.google.com"
         ],
         "created_date": "2003-03-17 12:20:05",
-        "expiration_date": "2021-03-17 12:48:36"
+        "created_date_parsed": "2003-03-17T12:20:05Z",
+        "expiration_date": "2021-03-17 12:48:36",
+        "expiration_date_parsed": "2021-03-17T12:48:36Z"
     },
     "registrar": {
         "name": "厦门易名科技股份有限公司"

--- a/testdata/noterror/co_git.co.json
+++ b/testdata/noterror/co_git.co.json
@@ -17,8 +17,11 @@
             "dns2.stabletransit.com"
         ],
         "created_date": "2010-07-21T21:16:03Z",
+        "created_date_parsed": "2010-07-21T21:16:03Z",
         "updated_date": "2019-07-21T12:37:14Z",
-        "expiration_date": "2020-07-20T23:59:59Z"
+        "updated_date_parsed": "2019-07-21T12:37:14Z",
+        "expiration_date": "2020-07-20T23:59:59Z",
+        "expiration_date_parsed": "2020-07-20T23:59:59Z"
     },
     "registrar": {
         "id": "146",

--- a/testdata/noterror/co_git.co.json
+++ b/testdata/noterror/co_git.co.json
@@ -17,11 +17,11 @@
             "dns2.stabletransit.com"
         ],
         "created_date": "2010-07-21T21:16:03Z",
-        "created_date_parsed": "2010-07-21T21:16:03Z",
+        "created_date_in_time": "2010-07-21T21:16:03Z",
         "updated_date": "2019-07-21T12:37:14Z",
-        "updated_date_parsed": "2019-07-21T12:37:14Z",
+        "updated_date_in_time": "2019-07-21T12:37:14Z",
         "expiration_date": "2020-07-20T23:59:59Z",
-        "expiration_date_parsed": "2020-07-20T23:59:59Z"
+        "expiration_date_in_time": "2020-07-20T23:59:59Z"
     },
     "registrar": {
         "id": "146",

--- a/testdata/noterror/co_google.co.json
+++ b/testdata/noterror/co_google.co.json
@@ -17,11 +17,11 @@
             "ns4.google.com"
         ],
         "created_date": "2010-02-25T01:04:59Z",
-        "created_date_parsed": "2010-02-25T01:04:59Z",
+        "created_date_in_time": "2010-02-25T01:04:59Z",
         "updated_date": "2019-01-28T10:39:22Z",
-        "updated_date_parsed": "2019-01-28T10:39:22Z",
+        "updated_date_in_time": "2019-01-28T10:39:22Z",
         "expiration_date": "2020-02-24T23:59:59Z",
-        "expiration_date_parsed": "2020-02-24T23:59:59Z"
+        "expiration_date_in_time": "2020-02-24T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/co_google.co.json
+++ b/testdata/noterror/co_google.co.json
@@ -17,8 +17,11 @@
             "ns4.google.com"
         ],
         "created_date": "2010-02-25T01:04:59Z",
+        "created_date_parsed": "2010-02-25T01:04:59Z",
         "updated_date": "2019-01-28T10:39:22Z",
-        "expiration_date": "2020-02-24T23:59:59Z"
+        "updated_date_parsed": "2019-01-28T10:39:22Z",
+        "expiration_date": "2020-02-24T23:59:59Z",
+        "expiration_date_parsed": "2020-02-24T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/com_com.json
+++ b/testdata/noterror/com_com.json
@@ -23,7 +23,9 @@
             "m.gtld-servers.net"
         ],
         "created_date": "1985-01-01",
-        "updated_date": "2017-10-05"
+        "created_date_parsed": "1985-01-01T00:00:00Z",
+        "updated_date": "2017-10-05",
+        "updated_date_parsed": "2017-10-05T00:00:00Z"
     },
     "registrant": {
         "organization": "VeriSign Global Registry Services",

--- a/testdata/noterror/com_com.json
+++ b/testdata/noterror/com_com.json
@@ -23,9 +23,9 @@
             "m.gtld-servers.net"
         ],
         "created_date": "1985-01-01",
-        "created_date_parsed": "1985-01-01T00:00:00Z",
+        "created_date_in_time": "1985-01-01T00:00:00Z",
         "updated_date": "2017-10-05",
-        "updated_date_parsed": "2017-10-05T00:00:00Z"
+        "updated_date_in_time": "2017-10-05T00:00:00Z"
     },
     "registrant": {
         "organization": "VeriSign Global Registry Services",

--- a/testdata/noterror/com_dynadot.com.json
+++ b/testdata/noterror/com_dynadot.com.json
@@ -14,8 +14,11 @@
             "ns2-geo.dynadot.com"
         ],
         "created_date": "2002-10-30T17:44:41.0Z",
+        "created_date_parsed": "2002-10-30T17:44:41Z",
         "updated_date": "2019-09-17T10:43:57.0Z",
-        "expiration_date": "2020-10-30T16:44:41.0Z"
+        "updated_date_parsed": "2019-09-17T10:43:57Z",
+        "expiration_date": "2020-10-30T16:44:41.0Z",
+        "expiration_date_parsed": "2020-10-30T16:44:41Z"
     },
     "registrar": {
         "id": "472",

--- a/testdata/noterror/com_dynadot.com.json
+++ b/testdata/noterror/com_dynadot.com.json
@@ -14,11 +14,11 @@
             "ns2-geo.dynadot.com"
         ],
         "created_date": "2002-10-30T17:44:41.0Z",
-        "created_date_parsed": "2002-10-30T17:44:41Z",
+        "created_date_in_time": "2002-10-30T17:44:41Z",
         "updated_date": "2019-09-17T10:43:57.0Z",
-        "updated_date_parsed": "2019-09-17T10:43:57Z",
+        "updated_date_in_time": "2019-09-17T10:43:57Z",
         "expiration_date": "2020-10-30T16:44:41.0Z",
-        "expiration_date_parsed": "2020-10-30T16:44:41Z"
+        "expiration_date_in_time": "2020-10-30T16:44:41Z"
     },
     "registrar": {
         "id": "472",

--- a/testdata/noterror/com_encirca.com.json
+++ b/testdata/noterror/com_encirca.com.json
@@ -15,8 +15,11 @@
             "dns4.encirca.com"
         ],
         "created_date": "1999-03-21T00:00:00Z",
+        "created_date_parsed": "1999-03-21T00:00:00Z",
         "updated_date": "2019-03-19T20:31:55Z",
-        "expiration_date": "2022-03-22T04:00:00Z"
+        "updated_date_parsed": "2019-03-19T20:31:55Z",
+        "expiration_date": "2022-03-22T04:00:00Z",
+        "expiration_date_parsed": "2022-03-22T04:00:00Z"
     },
     "registrar": {
         "id": "455",

--- a/testdata/noterror/com_encirca.com.json
+++ b/testdata/noterror/com_encirca.com.json
@@ -15,11 +15,11 @@
             "dns4.encirca.com"
         ],
         "created_date": "1999-03-21T00:00:00Z",
-        "created_date_parsed": "1999-03-21T00:00:00Z",
+        "created_date_in_time": "1999-03-21T00:00:00Z",
         "updated_date": "2019-03-19T20:31:55Z",
-        "updated_date_parsed": "2019-03-19T20:31:55Z",
+        "updated_date_in_time": "2019-03-19T20:31:55Z",
         "expiration_date": "2022-03-22T04:00:00Z",
-        "expiration_date_parsed": "2022-03-22T04:00:00Z"
+        "expiration_date_in_time": "2022-03-22T04:00:00Z"
     },
     "registrar": {
         "id": "455",

--- a/testdata/noterror/com_name.com.json
+++ b/testdata/noterror/com_name.com.json
@@ -24,8 +24,11 @@
             "eur2.akam.net"
         ],
         "created_date": "1995-01-03T05:00:00Z",
+        "created_date_parsed": "1995-01-03T05:00:00Z",
         "updated_date": "2014-04-18T17:04:21Z",
-        "expiration_date": "2019-11-04T00:00:00Z"
+        "updated_date_parsed": "2014-04-18T17:04:21Z",
+        "expiration_date": "2019-11-04T00:00:00Z",
+        "expiration_date_parsed": "2019-11-04T00:00:00Z"
     },
     "registrar": {
         "id": "625",

--- a/testdata/noterror/com_name.com.json
+++ b/testdata/noterror/com_name.com.json
@@ -24,11 +24,11 @@
             "eur2.akam.net"
         ],
         "created_date": "1995-01-03T05:00:00Z",
-        "created_date_parsed": "1995-01-03T05:00:00Z",
+        "created_date_in_time": "1995-01-03T05:00:00Z",
         "updated_date": "2014-04-18T17:04:21Z",
-        "updated_date_parsed": "2014-04-18T17:04:21Z",
+        "updated_date_in_time": "2014-04-18T17:04:21Z",
         "expiration_date": "2019-11-04T00:00:00Z",
-        "expiration_date_parsed": "2019-11-04T00:00:00Z"
+        "expiration_date_in_time": "2019-11-04T00:00:00Z"
     },
     "registrar": {
         "id": "625",

--- a/testdata/noterror/com_rockcreekcc.com.json
+++ b/testdata/noterror/com_rockcreekcc.com.json
@@ -15,11 +15,11 @@
             "ns2.sterlink.net"
         ],
         "created_date": "2002-07-12T15:48:26Z",
-        "created_date_parsed": "2002-07-12T15:48:26Z",
+        "created_date_in_time": "2002-07-12T15:48:26Z",
         "updated_date": "2021-05-03T20:23:19Z",
-        "updated_date_parsed": "2021-05-03T20:23:19Z",
+        "updated_date_in_time": "2021-05-03T20:23:19Z",
         "expiration_date": "2022-07-12T15:48:26Z",
-        "expiration_date_parsed": "2022-07-12T15:48:26Z"
+        "expiration_date_in_time": "2022-07-12T15:48:26Z"
     },
     "registrar": {
         "id": "69",

--- a/testdata/noterror/com_rockcreekcc.com.json
+++ b/testdata/noterror/com_rockcreekcc.com.json
@@ -15,8 +15,11 @@
             "ns2.sterlink.net"
         ],
         "created_date": "2002-07-12T15:48:26Z",
+        "created_date_parsed": "2002-07-12T15:48:26Z",
         "updated_date": "2021-05-03T20:23:19Z",
-        "expiration_date": "2022-07-12T15:48:26Z"
+        "updated_date_parsed": "2021-05-03T20:23:19Z",
+        "expiration_date": "2022-07-12T15:48:26Z",
+        "expiration_date_parsed": "2022-07-12T15:48:26Z"
     },
     "registrar": {
         "id": "69",

--- a/testdata/noterror/coop_git.coop.json
+++ b/testdata/noterror/coop_git.coop.json
@@ -16,8 +16,11 @@
             "dns2.webarch.info"
         ],
         "created_date": "2017-02-22T14:29:09.0Z",
+        "created_date_parsed": "2017-02-22T14:29:09Z",
         "updated_date": "2019-03-21T09:46:54.0Z",
-        "expiration_date": "2020-02-22T23:59:59.0Z"
+        "updated_date_parsed": "2019-03-21T09:46:54Z",
+        "expiration_date": "2020-02-22T23:59:59.0Z",
+        "expiration_date_parsed": "2020-02-22T23:59:59Z"
     },
     "registrar": {
         "id": "81",

--- a/testdata/noterror/coop_git.coop.json
+++ b/testdata/noterror/coop_git.coop.json
@@ -16,11 +16,11 @@
             "dns2.webarch.info"
         ],
         "created_date": "2017-02-22T14:29:09.0Z",
-        "created_date_parsed": "2017-02-22T14:29:09Z",
+        "created_date_in_time": "2017-02-22T14:29:09Z",
         "updated_date": "2019-03-21T09:46:54.0Z",
-        "updated_date_parsed": "2019-03-21T09:46:54Z",
+        "updated_date_in_time": "2019-03-21T09:46:54Z",
         "expiration_date": "2020-02-22T23:59:59.0Z",
-        "expiration_date_parsed": "2020-02-22T23:59:59Z"
+        "expiration_date_in_time": "2020-02-22T23:59:59Z"
     },
     "registrar": {
         "id": "81",

--- a/testdata/noterror/coop_slb.coop.json
+++ b/testdata/noterror/coop_slb.coop.json
@@ -15,8 +15,11 @@
             "ns-148-c.gandi.net"
         ],
         "created_date": "2014-07-04T10:24:18.0Z",
+        "created_date_parsed": "2014-07-04T10:24:18Z",
         "updated_date": "2019-07-09T09:44:08.0Z",
-        "expiration_date": "2020-07-04T23:59:59.0Z"
+        "updated_date_parsed": "2019-07-09T09:44:08Z",
+        "expiration_date": "2020-07-04T23:59:59.0Z",
+        "expiration_date_parsed": "2020-07-04T23:59:59Z"
     },
     "registrar": {
         "id": "81",

--- a/testdata/noterror/coop_slb.coop.json
+++ b/testdata/noterror/coop_slb.coop.json
@@ -15,11 +15,11 @@
             "ns-148-c.gandi.net"
         ],
         "created_date": "2014-07-04T10:24:18.0Z",
-        "created_date_parsed": "2014-07-04T10:24:18Z",
+        "created_date_in_time": "2014-07-04T10:24:18Z",
         "updated_date": "2019-07-09T09:44:08.0Z",
-        "updated_date_parsed": "2019-07-09T09:44:08Z",
+        "updated_date_in_time": "2019-07-09T09:44:08Z",
         "expiration_date": "2020-07-04T23:59:59.0Z",
-        "expiration_date_parsed": "2020-07-04T23:59:59Z"
+        "expiration_date_in_time": "2020-07-04T23:59:59Z"
     },
     "registrar": {
         "id": "81",

--- a/testdata/noterror/cx_git.cx.json
+++ b/testdata/noterror/cx_git.cx.json
@@ -15,11 +15,11 @@
             "ns100.ovh.net"
         ],
         "created_date": "2012-01-26T05:49:44.787Z",
-        "created_date_parsed": "2012-01-26T05:49:44.787Z",
+        "created_date_in_time": "2012-01-26T05:49:44.787Z",
         "updated_date": "2019-01-01T18:14:16.77Z",
-        "updated_date_parsed": "2019-01-01T18:14:16.77Z",
+        "updated_date_in_time": "2019-01-01T18:14:16.77Z",
         "expiration_date": "2020-01-26T05:52:26.85Z",
-        "expiration_date_parsed": "2020-01-26T05:52:26.85Z"
+        "expiration_date_in_time": "2020-01-26T05:52:26.85Z"
     },
     "registrar": {
         "id": "433",

--- a/testdata/noterror/cx_git.cx.json
+++ b/testdata/noterror/cx_git.cx.json
@@ -15,8 +15,11 @@
             "ns100.ovh.net"
         ],
         "created_date": "2012-01-26T05:49:44.787Z",
+        "created_date_parsed": "2012-01-26T05:49:44.787Z",
         "updated_date": "2019-01-01T18:14:16.77Z",
-        "expiration_date": "2020-01-26T05:52:26.85Z"
+        "updated_date_parsed": "2019-01-01T18:14:16.77Z",
+        "expiration_date": "2020-01-26T05:52:26.85Z",
+        "expiration_date_parsed": "2020-01-26T05:52:26.85Z"
     },
     "registrar": {
         "id": "433",

--- a/testdata/noterror/cx_google.cx.json
+++ b/testdata/noterror/cx_google.cx.json
@@ -21,11 +21,11 @@
             "ns2.google.com"
         ],
         "created_date": "2010-07-29T18:15:42.56Z",
-        "created_date_parsed": "2010-07-29T18:15:42.56Z",
+        "created_date_in_time": "2010-07-29T18:15:42.56Z",
         "updated_date": "2019-06-27T09:31:23.513Z",
-        "updated_date_parsed": "2019-06-27T09:31:23.513Z",
+        "updated_date_in_time": "2019-06-27T09:31:23.513Z",
         "expiration_date": "2020-07-29T18:15:42.158Z",
-        "expiration_date_parsed": "2020-07-29T18:15:42.158Z"
+        "expiration_date_in_time": "2020-07-29T18:15:42.158Z"
     },
     "registrar": {
         "name": "MarkMonitor",

--- a/testdata/noterror/cx_google.cx.json
+++ b/testdata/noterror/cx_google.cx.json
@@ -21,8 +21,11 @@
             "ns2.google.com"
         ],
         "created_date": "2010-07-29T18:15:42.56Z",
+        "created_date_parsed": "2010-07-29T18:15:42.56Z",
         "updated_date": "2019-06-27T09:31:23.513Z",
-        "expiration_date": "2020-07-29T18:15:42.158Z"
+        "updated_date_parsed": "2019-06-27T09:31:23.513Z",
+        "expiration_date": "2020-07-29T18:15:42.158Z",
+        "expiration_date_parsed": "2020-07-29T18:15:42.158Z"
     },
     "registrar": {
         "name": "MarkMonitor",

--- a/testdata/noterror/cymru_cgi.cymru.json
+++ b/testdata/noterror/cymru_cgi.cymru.json
@@ -13,8 +13,11 @@
             "dns2.cscdns.net"
         ],
         "created_date": "2015-03-10T14:06:10Z",
+        "created_date_parsed": "2015-03-10T14:06:10Z",
         "updated_date": "2019-09-09T09:34:52Z",
-        "expiration_date": "2021-03-10T14:06:10Z"
+        "updated_date_parsed": "2019-09-09T09:34:52Z",
+        "expiration_date": "2021-03-10T14:06:10Z",
+        "expiration_date_parsed": "2021-03-10T14:06:10Z"
     },
     "registrar": {
         "id": "299",

--- a/testdata/noterror/cymru_cgi.cymru.json
+++ b/testdata/noterror/cymru_cgi.cymru.json
@@ -13,11 +13,11 @@
             "dns2.cscdns.net"
         ],
         "created_date": "2015-03-10T14:06:10Z",
-        "created_date_parsed": "2015-03-10T14:06:10Z",
+        "created_date_in_time": "2015-03-10T14:06:10Z",
         "updated_date": "2019-09-09T09:34:52Z",
-        "updated_date_parsed": "2019-09-09T09:34:52Z",
+        "updated_date_in_time": "2019-09-09T09:34:52Z",
         "expiration_date": "2021-03-10T14:06:10Z",
-        "expiration_date_parsed": "2021-03-10T14:06:10Z"
+        "expiration_date_in_time": "2021-03-10T14:06:10Z"
     },
     "registrar": {
         "id": "299",

--- a/testdata/noterror/cymru_google.cymru.json
+++ b/testdata/noterror/cymru_google.cymru.json
@@ -17,11 +17,11 @@
             "ns2.google.com"
         ],
         "created_date": "2014-10-31T13:27:48Z",
-        "created_date_parsed": "2014-10-31T13:27:48Z",
+        "created_date_in_time": "2014-10-31T13:27:48Z",
         "updated_date": "2019-09-29T09:41:07Z",
-        "updated_date_parsed": "2019-09-29T09:41:07Z",
+        "updated_date_in_time": "2019-09-29T09:41:07Z",
         "expiration_date": "2020-10-31T13:27:48Z",
-        "expiration_date_parsed": "2020-10-31T13:27:48Z"
+        "expiration_date_in_time": "2020-10-31T13:27:48Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/cymru_google.cymru.json
+++ b/testdata/noterror/cymru_google.cymru.json
@@ -17,8 +17,11 @@
             "ns2.google.com"
         ],
         "created_date": "2014-10-31T13:27:48Z",
+        "created_date_parsed": "2014-10-31T13:27:48Z",
         "updated_date": "2019-09-29T09:41:07Z",
-        "expiration_date": "2020-10-31T13:27:48Z"
+        "updated_date_parsed": "2019-09-29T09:41:07Z",
+        "expiration_date": "2020-10-31T13:27:48Z",
+        "expiration_date_parsed": "2020-10-31T13:27:48Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/de_git.de.json
+++ b/testdata/noterror/de_git.de.json
@@ -13,6 +13,6 @@
             "ns3.webcoding24.com"
         ],
         "updated_date": "2008-10-22T11:33:44+02:00",
-        "updated_date_parsed": "2008-10-22T11:33:44+02:00"
+        "updated_date_in_time": "2008-10-22T11:33:44+02:00"
     }
 }

--- a/testdata/noterror/de_git.de.json
+++ b/testdata/noterror/de_git.de.json
@@ -12,6 +12,7 @@
             "ns2.webcoding24.com",
             "ns3.webcoding24.com"
         ],
-        "updated_date": "2008-10-22T11:33:44+02:00"
+        "updated_date": "2008-10-22T11:33:44+02:00",
+        "updated_date_parsed": "2008-10-22T11:33:44+02:00"
     }
 }

--- a/testdata/noterror/de_google.de.json
+++ b/testdata/noterror/de_google.de.json
@@ -14,6 +14,6 @@
             "ns4.google.com"
         ],
         "updated_date": "2018-03-12T21:44:25+01:00",
-        "updated_date_parsed": "2018-03-12T21:44:25+01:00"
+        "updated_date_in_time": "2018-03-12T21:44:25+01:00"
     }
 }

--- a/testdata/noterror/de_google.de.json
+++ b/testdata/noterror/de_google.de.json
@@ -13,6 +13,7 @@
             "ns3.google.com",
             "ns4.google.com"
         ],
-        "updated_date": "2018-03-12T21:44:25+01:00"
+        "updated_date": "2018-03-12T21:44:25+01:00",
+        "updated_date_parsed": "2018-03-12T21:44:25+01:00"
     }
 }

--- a/testdata/noterror/edu_cornell.edu.json
+++ b/testdata/noterror/edu_cornell.edu.json
@@ -12,8 +12,11 @@
             "drdns2.cit.cornell.edu"
         ],
         "created_date": "15-Jul-1985",
+        "created_date_parsed": "1985-07-15T00:00:00Z",
         "updated_date": "30-Jun-2020",
-        "expiration_date": "31-Jul-2022"
+        "updated_date_parsed": "2020-06-30T00:00:00Z",
+        "expiration_date": "31-Jul-2022",
+        "expiration_date_parsed": "2022-07-31T00:00:00Z"
     },
     "registrant": {
         "organization": "Cornell University",

--- a/testdata/noterror/edu_cornell.edu.json
+++ b/testdata/noterror/edu_cornell.edu.json
@@ -12,11 +12,11 @@
             "drdns2.cit.cornell.edu"
         ],
         "created_date": "15-Jul-1985",
-        "created_date_parsed": "1985-07-15T00:00:00Z",
+        "created_date_in_time": "1985-07-15T00:00:00Z",
         "updated_date": "30-Jun-2020",
-        "updated_date_parsed": "2020-06-30T00:00:00Z",
+        "updated_date_in_time": "2020-06-30T00:00:00Z",
         "expiration_date": "31-Jul-2022",
-        "expiration_date_parsed": "2022-07-31T00:00:00Z"
+        "expiration_date_in_time": "2022-07-31T00:00:00Z"
     },
     "registrant": {
         "organization": "Cornell University",

--- a/testdata/noterror/edu_rutgers.edu.json
+++ b/testdata/noterror/edu_rutgers.edu.json
@@ -10,11 +10,11 @@
             "ns87.a0.incapsecuredns.net"
         ],
         "created_date": "25-Apr-1985",
-        "created_date_parsed": "1985-04-25T00:00:00Z",
+        "created_date_in_time": "1985-04-25T00:00:00Z",
         "updated_date": "25-Mar-2020",
-        "updated_date_parsed": "2020-03-25T00:00:00Z",
+        "updated_date_in_time": "2020-03-25T00:00:00Z",
         "expiration_date": "31-Jul-2020",
-        "expiration_date_parsed": "2020-07-31T00:00:00Z"
+        "expiration_date_in_time": "2020-07-31T00:00:00Z"
     },
     "registrant": {
         "organization": "Rutgers, The State University of New Jersey",

--- a/testdata/noterror/edu_rutgers.edu.json
+++ b/testdata/noterror/edu_rutgers.edu.json
@@ -10,8 +10,11 @@
             "ns87.a0.incapsecuredns.net"
         ],
         "created_date": "25-Apr-1985",
+        "created_date_parsed": "1985-04-25T00:00:00Z",
         "updated_date": "25-Mar-2020",
-        "expiration_date": "31-Jul-2020"
+        "updated_date_parsed": "2020-03-25T00:00:00Z",
+        "expiration_date": "31-Jul-2020",
+        "expiration_date_parsed": "2020-07-31T00:00:00Z"
     },
     "registrant": {
         "organization": "Rutgers, The State University of New Jersey",

--- a/testdata/noterror/edu_snai.edu.json
+++ b/testdata/noterror/edu_snai.edu.json
@@ -9,11 +9,11 @@
             "ns2.alidns.com"
         ],
         "created_date": "27-Apr-2001",
-        "created_date_parsed": "2001-04-27T00:00:00Z",
+        "created_date_in_time": "2001-04-27T00:00:00Z",
         "updated_date": "08-Jan-2019",
-        "updated_date_parsed": "2019-01-08T00:00:00Z",
+        "updated_date_in_time": "2019-01-08T00:00:00Z",
         "expiration_date": "31-Jul-2021",
-        "expiration_date_parsed": "2021-07-31T00:00:00Z"
+        "expiration_date_in_time": "2021-07-31T00:00:00Z"
     },
     "registrant": {
         "organization": "Shanghai National Accounting Institute",

--- a/testdata/noterror/edu_snai.edu.json
+++ b/testdata/noterror/edu_snai.edu.json
@@ -9,8 +9,11 @@
             "ns2.alidns.com"
         ],
         "created_date": "27-Apr-2001",
+        "created_date_parsed": "2001-04-27T00:00:00Z",
         "updated_date": "08-Jan-2019",
-        "expiration_date": "31-Jul-2021"
+        "updated_date_parsed": "2019-01-08T00:00:00Z",
+        "expiration_date": "31-Jul-2021",
+        "expiration_date_parsed": "2021-07-31T00:00:00Z"
     },
     "registrant": {
         "organization": "Shanghai National Accounting Institute",

--- a/testdata/noterror/edu_unm.edu.json
+++ b/testdata/noterror/edu_unm.edu.json
@@ -9,8 +9,11 @@
             "ns2.unm.edu"
         ],
         "created_date": "27-Aug-1986",
+        "created_date_parsed": "1986-08-27T00:00:00Z",
         "updated_date": "13-Aug-2020",
-        "expiration_date": "31-Jul-2023"
+        "updated_date_parsed": "2020-08-13T00:00:00Z",
+        "expiration_date": "31-Jul-2023",
+        "expiration_date_parsed": "2023-07-31T00:00:00Z"
     },
     "registrant": {
         "organization": "University of New Mexico",

--- a/testdata/noterror/edu_unm.edu.json
+++ b/testdata/noterror/edu_unm.edu.json
@@ -9,11 +9,11 @@
             "ns2.unm.edu"
         ],
         "created_date": "27-Aug-1986",
-        "created_date_parsed": "1986-08-27T00:00:00Z",
+        "created_date_in_time": "1986-08-27T00:00:00Z",
         "updated_date": "13-Aug-2020",
-        "updated_date_parsed": "2020-08-13T00:00:00Z",
+        "updated_date_in_time": "2020-08-13T00:00:00Z",
         "expiration_date": "31-Jul-2023",
-        "expiration_date_parsed": "2023-07-31T00:00:00Z"
+        "expiration_date_in_time": "2023-07-31T00:00:00Z"
     },
     "registrant": {
         "organization": "University of New Mexico",

--- a/testdata/noterror/ee_git.ee.json
+++ b/testdata/noterror/ee_git.ee.json
@@ -14,7 +14,7 @@
         "created_date": "2011-01-23 00:00:07 +02:00",
         "updated_date": "2013-05-23 00:30:06 +03:00",
         "expiration_date": "2021-01-24",
-        "expiration_date_parsed": "2021-01-24T00:00:00Z"
+        "expiration_date_in_time": "2021-01-24T00:00:00Z"
     },
     "registrar": {
         "name": "Zone Media OÜ",

--- a/testdata/noterror/ee_git.ee.json
+++ b/testdata/noterror/ee_git.ee.json
@@ -13,7 +13,8 @@
         ],
         "created_date": "2011-01-23 00:00:07 +02:00",
         "updated_date": "2013-05-23 00:30:06 +03:00",
-        "expiration_date": "2021-01-24"
+        "expiration_date": "2021-01-24",
+        "expiration_date_parsed": "2021-01-24T00:00:00Z"
     },
     "registrar": {
         "name": "Zone Media OÜ",

--- a/testdata/noterror/ee_google.ee.json
+++ b/testdata/noterror/ee_google.ee.json
@@ -15,7 +15,8 @@
         ],
         "created_date": "2010-07-04 04:34:46 +03:00",
         "updated_date": "2010-11-10 14:15:06 +02:00",
-        "expiration_date": "2021-11-09"
+        "expiration_date": "2021-11-09",
+        "expiration_date_parsed": "2021-11-09T00:00:00Z"
     },
     "registrar": {
         "name": "Zone Media OÜ",

--- a/testdata/noterror/ee_google.ee.json
+++ b/testdata/noterror/ee_google.ee.json
@@ -16,7 +16,7 @@
         "created_date": "2010-07-04 04:34:46 +03:00",
         "updated_date": "2010-11-10 14:15:06 +02:00",
         "expiration_date": "2021-11-09",
-        "expiration_date_parsed": "2021-11-09T00:00:00Z"
+        "expiration_date_in_time": "2021-11-09T00:00:00Z"
     },
     "registrar": {
         "name": "Zone Media OÜ",

--- a/testdata/noterror/ee_telia.ee.json
+++ b/testdata/noterror/ee_telia.ee.json
@@ -14,7 +14,7 @@
         "created_date": "2011-08-09 09:45:08 +03:00",
         "updated_date": "2014-11-05 16:32:15 +02:00",
         "expiration_date": "2021-08-10",
-        "expiration_date_parsed": "2021-08-10T00:00:00Z"
+        "expiration_date_in_time": "2021-08-10T00:00:00Z"
     },
     "registrar": {
         "name": "Telia Eesti AS",

--- a/testdata/noterror/ee_telia.ee.json
+++ b/testdata/noterror/ee_telia.ee.json
@@ -13,7 +13,8 @@
         ],
         "created_date": "2011-08-09 09:45:08 +03:00",
         "updated_date": "2014-11-05 16:32:15 +02:00",
-        "expiration_date": "2021-08-10"
+        "expiration_date": "2021-08-10",
+        "expiration_date_parsed": "2021-08-10T00:00:00Z"
     },
     "registrar": {
         "name": "Telia Eesti AS",

--- a/testdata/noterror/fi_git.fi.json
+++ b/testdata/noterror/fi_git.fi.json
@@ -14,8 +14,10 @@
             "ns-1849.awsdns-39.co.uk"
         ],
         "created_date": "15.12.2015 09:48:01",
+        "created_date_parsed": "2015-12-15T09:48:01Z",
         "updated_date": "19.2.2019",
-        "expiration_date": "15.12.2020 09:37:54"
+        "expiration_date": "15.12.2020 09:37:54",
+        "expiration_date_parsed": "2020-12-15T09:37:54Z"
     },
     "registrar": {
         "name": "Gandi SAS",

--- a/testdata/noterror/fi_git.fi.json
+++ b/testdata/noterror/fi_git.fi.json
@@ -14,10 +14,10 @@
             "ns-1849.awsdns-39.co.uk"
         ],
         "created_date": "15.12.2015 09:48:01",
-        "created_date_parsed": "2015-12-15T09:48:01Z",
+        "created_date_in_time": "2015-12-15T09:48:01Z",
         "updated_date": "19.2.2019",
         "expiration_date": "15.12.2020 09:37:54",
-        "expiration_date_parsed": "2020-12-15T09:37:54Z"
+        "expiration_date_in_time": "2020-12-15T09:37:54Z"
     },
     "registrar": {
         "name": "Gandi SAS",

--- a/testdata/noterror/fi_google.fi.json
+++ b/testdata/noterror/fi_google.fi.json
@@ -14,8 +14,10 @@
             "ns2.google.com"
         ],
         "created_date": "30.6.2006 00:00:00",
+        "created_date_parsed": "2006-06-30T00:00:00Z",
         "updated_date": "2.6.2019",
-        "expiration_date": "4.7.2020 10:15:55"
+        "expiration_date": "4.7.2020 10:15:55",
+        "expiration_date_parsed": "2020-07-04T10:15:55Z"
     },
     "registrar": {
         "name": "MarkMonitor Inc.",

--- a/testdata/noterror/fi_google.fi.json
+++ b/testdata/noterror/fi_google.fi.json
@@ -14,10 +14,10 @@
             "ns2.google.com"
         ],
         "created_date": "30.6.2006 00:00:00",
-        "created_date_parsed": "2006-06-30T00:00:00Z",
+        "created_date_in_time": "2006-06-30T00:00:00Z",
         "updated_date": "2.6.2019",
         "expiration_date": "4.7.2020 10:15:55",
-        "expiration_date_parsed": "2020-07-04T10:15:55Z"
+        "expiration_date_in_time": "2020-07-04T10:15:55Z"
     },
     "registrar": {
         "name": "MarkMonitor Inc.",

--- a/testdata/noterror/fr_git.fr.json
+++ b/testdata/noterror/fr_git.fr.json
@@ -12,8 +12,11 @@
             "dns104.ovh.net"
         ],
         "created_date": "1999-12-22T23:00:00Z",
+        "created_date_parsed": "1999-12-22T23:00:00Z",
         "updated_date": "2019-05-05T08:38:28Z",
-        "expiration_date": "2020-05-05T08:07:09Z"
+        "updated_date_parsed": "2019-05-05T08:38:28Z",
+        "expiration_date": "2020-05-05T08:07:09Z",
+        "expiration_date_parsed": "2020-05-05T08:07:09Z"
     },
     "registrar": {
         "name": "OVH",

--- a/testdata/noterror/fr_git.fr.json
+++ b/testdata/noterror/fr_git.fr.json
@@ -12,11 +12,11 @@
             "dns104.ovh.net"
         ],
         "created_date": "1999-12-22T23:00:00Z",
-        "created_date_parsed": "1999-12-22T23:00:00Z",
+        "created_date_in_time": "1999-12-22T23:00:00Z",
         "updated_date": "2019-05-05T08:38:28Z",
-        "updated_date_parsed": "2019-05-05T08:38:28Z",
+        "updated_date_in_time": "2019-05-05T08:38:28Z",
         "expiration_date": "2020-05-05T08:07:09Z",
-        "expiration_date_parsed": "2020-05-05T08:07:09Z"
+        "expiration_date_in_time": "2020-05-05T08:07:09Z"
     },
     "registrar": {
         "name": "OVH",

--- a/testdata/noterror/fr_google.fr.json
+++ b/testdata/noterror/fr_google.fr.json
@@ -14,8 +14,11 @@
             "ns4.google.com"
         ],
         "created_date": "2000-07-26T22:00:00Z",
+        "created_date_parsed": "2000-07-26T22:00:00Z",
         "updated_date": "2018-11-28T10:31:42Z",
-        "expiration_date": "2019-12-30T17:16:48Z"
+        "updated_date_parsed": "2018-11-28T10:31:42Z",
+        "expiration_date": "2019-12-30T17:16:48Z",
+        "expiration_date_parsed": "2019-12-30T17:16:48Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/fr_google.fr.json
+++ b/testdata/noterror/fr_google.fr.json
@@ -14,11 +14,11 @@
             "ns4.google.com"
         ],
         "created_date": "2000-07-26T22:00:00Z",
-        "created_date_parsed": "2000-07-26T22:00:00Z",
+        "created_date_in_time": "2000-07-26T22:00:00Z",
         "updated_date": "2018-11-28T10:31:42Z",
-        "updated_date_parsed": "2018-11-28T10:31:42Z",
+        "updated_date_in_time": "2018-11-28T10:31:42Z",
         "expiration_date": "2019-12-30T17:16:48Z",
-        "expiration_date_parsed": "2019-12-30T17:16:48Z"
+        "expiration_date_in_time": "2019-12-30T17:16:48Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/fr_ovh.fr.json
+++ b/testdata/noterror/fr_ovh.fr.json
@@ -14,8 +14,11 @@
             "ns10.ovh.net"
         ],
         "created_date": "1999-11-11T23:00:00Z",
+        "created_date_parsed": "1999-11-11T23:00:00Z",
         "updated_date": "2019-04-18T12:14:43Z",
-        "expiration_date": "2019-11-11T23:00:00Z"
+        "updated_date_parsed": "2019-04-18T12:14:43Z",
+        "expiration_date": "2019-11-11T23:00:00Z",
+        "expiration_date_parsed": "2019-11-11T23:00:00Z"
     },
     "registrar": {
         "name": "OVH",

--- a/testdata/noterror/fr_ovh.fr.json
+++ b/testdata/noterror/fr_ovh.fr.json
@@ -14,11 +14,11 @@
             "ns10.ovh.net"
         ],
         "created_date": "1999-11-11T23:00:00Z",
-        "created_date_parsed": "1999-11-11T23:00:00Z",
+        "created_date_in_time": "1999-11-11T23:00:00Z",
         "updated_date": "2019-04-18T12:14:43Z",
-        "updated_date_parsed": "2019-04-18T12:14:43Z",
+        "updated_date_in_time": "2019-04-18T12:14:43Z",
         "expiration_date": "2019-11-11T23:00:00Z",
-        "expiration_date_parsed": "2019-11-11T23:00:00Z"
+        "expiration_date_in_time": "2019-11-11T23:00:00Z"
     },
     "registrar": {
         "name": "OVH",

--- a/testdata/noterror/google_google.json
+++ b/testdata/noterror/google_google.json
@@ -15,9 +15,9 @@
             "ns-tld5.charlestonroadregistry.com"
         ],
         "created_date": "2014-09-04",
-        "created_date_parsed": "2014-09-04T00:00:00Z",
+        "created_date_in_time": "2014-09-04T00:00:00Z",
         "updated_date": "2019-07-02",
-        "updated_date_parsed": "2019-07-02T00:00:00Z"
+        "updated_date_in_time": "2019-07-02T00:00:00Z"
     },
     "registrant": {
         "organization": "Charleston Road Registry Inc.",

--- a/testdata/noterror/google_google.json
+++ b/testdata/noterror/google_google.json
@@ -15,7 +15,9 @@
             "ns-tld5.charlestonroadregistry.com"
         ],
         "created_date": "2014-09-04",
-        "updated_date": "2019-07-02"
+        "created_date_parsed": "2014-09-04T00:00:00Z",
+        "updated_date": "2019-07-02",
+        "updated_date_parsed": "2019-07-02T00:00:00Z"
     },
     "registrant": {
         "organization": "Charleston Road Registry Inc.",

--- a/testdata/noterror/gs_git.gs.json
+++ b/testdata/noterror/gs_git.gs.json
@@ -17,11 +17,11 @@
             "ns5.linode.com"
         ],
         "created_date": "2013-04-19T12:25:43.248Z",
-        "created_date_parsed": "2013-04-19T12:25:43.248Z",
+        "created_date_in_time": "2013-04-19T12:25:43.248Z",
         "updated_date": "2019-03-28T17:14:27.619Z",
-        "updated_date_parsed": "2019-03-28T17:14:27.619Z",
+        "updated_date_in_time": "2019-03-28T17:14:27.619Z",
         "expiration_date": "2020-04-19T12:25:43.504Z",
-        "expiration_date_parsed": "2020-04-19T12:25:43.504Z"
+        "expiration_date_in_time": "2020-04-19T12:25:43.504Z"
     },
     "registrar": {
         "name": "Name.com LLC",

--- a/testdata/noterror/gs_git.gs.json
+++ b/testdata/noterror/gs_git.gs.json
@@ -17,8 +17,11 @@
             "ns5.linode.com"
         ],
         "created_date": "2013-04-19T12:25:43.248Z",
+        "created_date_parsed": "2013-04-19T12:25:43.248Z",
         "updated_date": "2019-03-28T17:14:27.619Z",
-        "expiration_date": "2020-04-19T12:25:43.504Z"
+        "updated_date_parsed": "2019-03-28T17:14:27.619Z",
+        "expiration_date": "2020-04-19T12:25:43.504Z",
+        "expiration_date_parsed": "2020-04-19T12:25:43.504Z"
     },
     "registrar": {
         "name": "Name.com LLC",

--- a/testdata/noterror/gs_google.gs.json
+++ b/testdata/noterror/gs_google.gs.json
@@ -19,8 +19,11 @@
             "ns2.google.com"
         ],
         "created_date": "2004-07-08T12:00:00.0Z",
+        "created_date_parsed": "2004-07-08T12:00:00Z",
         "updated_date": "2019-06-06T09:32:35.587Z",
-        "expiration_date": "2020-07-08T12:00:00.0Z"
+        "updated_date_parsed": "2019-06-06T09:32:35.587Z",
+        "expiration_date": "2020-07-08T12:00:00.0Z",
+        "expiration_date_parsed": "2020-07-08T12:00:00Z"
     },
     "registrar": {
         "name": "MarkMonitor",

--- a/testdata/noterror/gs_google.gs.json
+++ b/testdata/noterror/gs_google.gs.json
@@ -19,11 +19,11 @@
             "ns2.google.com"
         ],
         "created_date": "2004-07-08T12:00:00.0Z",
-        "created_date_parsed": "2004-07-08T12:00:00Z",
+        "created_date_in_time": "2004-07-08T12:00:00Z",
         "updated_date": "2019-06-06T09:32:35.587Z",
-        "updated_date_parsed": "2019-06-06T09:32:35.587Z",
+        "updated_date_in_time": "2019-06-06T09:32:35.587Z",
         "expiration_date": "2020-07-08T12:00:00.0Z",
-        "expiration_date_parsed": "2020-07-08T12:00:00Z"
+        "expiration_date_in_time": "2020-07-08T12:00:00Z"
     },
     "registrar": {
         "name": "MarkMonitor",

--- a/testdata/noterror/hk_git.hk.json
+++ b/testdata/noterror/hk_git.hk.json
@@ -12,9 +12,9 @@
             "f1g1ns2.dnspod.net"
         ],
         "created_date": "11-07-2017",
-        "created_date_parsed": "2017-07-11T00:00:00Z",
+        "created_date_in_time": "2017-07-11T00:00:00Z",
         "expiration_date": "11-07-2020",
-        "expiration_date_parsed": "2020-07-11T00:00:00Z"
+        "expiration_date_in_time": "2020-07-11T00:00:00Z"
     },
     "registrar": {
         "name": "WEST263 INTERNATIONAL LIMITED"

--- a/testdata/noterror/hk_git.hk.json
+++ b/testdata/noterror/hk_git.hk.json
@@ -12,7 +12,9 @@
             "f1g1ns2.dnspod.net"
         ],
         "created_date": "11-07-2017",
-        "expiration_date": "11-07-2020"
+        "created_date_parsed": "2017-07-11T00:00:00Z",
+        "expiration_date": "11-07-2020",
+        "expiration_date_parsed": "2020-07-11T00:00:00Z"
     },
     "registrar": {
         "name": "WEST263 INTERNATIONAL LIMITED"

--- a/testdata/noterror/hk_google.hk.json
+++ b/testdata/noterror/hk_google.hk.json
@@ -14,9 +14,9 @@
             "ns4.google.com"
         ],
         "created_date": "06-04-2004",
-        "created_date_parsed": "2004-04-06T00:00:00Z",
+        "created_date_in_time": "2004-04-06T00:00:00Z",
         "expiration_date": "31-03-2020",
-        "expiration_date_parsed": "2020-03-31T00:00:00Z"
+        "expiration_date_in_time": "2020-03-31T00:00:00Z"
     },
     "registrar": {
         "name": "MARKMONITOR INC.",

--- a/testdata/noterror/hk_google.hk.json
+++ b/testdata/noterror/hk_google.hk.json
@@ -14,7 +14,9 @@
             "ns4.google.com"
         ],
         "created_date": "06-04-2004",
-        "expiration_date": "31-03-2020"
+        "created_date_parsed": "2004-04-06T00:00:00Z",
+        "expiration_date": "31-03-2020",
+        "expiration_date_parsed": "2020-03-31T00:00:00Z"
     },
     "registrar": {
         "name": "MARKMONITOR INC.",

--- a/testdata/noterror/hk_ibm.hk.json
+++ b/testdata/noterror/hk_ibm.hk.json
@@ -17,7 +17,9 @@
             "usc3.akam.net"
         ],
         "created_date": "14-03-2004",
-        "expiration_date": "03-04-2020"
+        "created_date_parsed": "2004-03-14T00:00:00Z",
+        "expiration_date": "03-04-2020",
+        "expiration_date_parsed": "2020-04-03T00:00:00Z"
     },
     "registrar": {
         "name": "Hong Kong Domain Name Registration Company Limited",

--- a/testdata/noterror/hk_ibm.hk.json
+++ b/testdata/noterror/hk_ibm.hk.json
@@ -17,9 +17,9 @@
             "usc3.akam.net"
         ],
         "created_date": "14-03-2004",
-        "created_date_parsed": "2004-03-14T00:00:00Z",
+        "created_date_in_time": "2004-03-14T00:00:00Z",
         "expiration_date": "03-04-2020",
-        "expiration_date_parsed": "2020-04-03T00:00:00Z"
+        "expiration_date_in_time": "2020-04-03T00:00:00Z"
     },
     "registrar": {
         "name": "Hong Kong Domain Name Registration Company Limited",

--- a/testdata/noterror/in_git.in.json
+++ b/testdata/noterror/in_git.in.json
@@ -13,11 +13,11 @@
             "ns2.parkingcrew.net"
         ],
         "created_date": "2005-02-16T06:54:49Z",
-        "created_date_parsed": "2005-02-16T06:54:49Z",
+        "created_date_in_time": "2005-02-16T06:54:49Z",
         "updated_date": "2019-03-15T19:06:26Z",
-        "updated_date_parsed": "2019-03-15T19:06:26Z",
+        "updated_date_in_time": "2019-03-15T19:06:26Z",
         "expiration_date": "2020-02-16T06:54:49Z",
-        "expiration_date_parsed": "2020-02-16T06:54:49Z"
+        "expiration_date_in_time": "2020-02-16T06:54:49Z"
     },
     "registrar": {
         "id": "801217",

--- a/testdata/noterror/in_git.in.json
+++ b/testdata/noterror/in_git.in.json
@@ -13,8 +13,11 @@
             "ns2.parkingcrew.net"
         ],
         "created_date": "2005-02-16T06:54:49Z",
+        "created_date_parsed": "2005-02-16T06:54:49Z",
         "updated_date": "2019-03-15T19:06:26Z",
-        "expiration_date": "2020-02-16T06:54:49Z"
+        "updated_date_parsed": "2019-03-15T19:06:26Z",
+        "expiration_date": "2020-02-16T06:54:49Z",
+        "expiration_date_parsed": "2020-02-16T06:54:49Z"
     },
     "registrar": {
         "id": "801217",

--- a/testdata/noterror/in_google.in.json
+++ b/testdata/noterror/in_google.in.json
@@ -17,11 +17,11 @@
             "ns3.google.com"
         ],
         "created_date": "2005-02-14T20:35:14Z",
-        "created_date_parsed": "2005-02-14T20:35:14Z",
+        "created_date_in_time": "2005-02-14T20:35:14Z",
         "updated_date": "2019-08-08T18:39:47Z",
-        "updated_date_parsed": "2019-08-08T18:39:47Z",
+        "updated_date_in_time": "2019-08-08T18:39:47Z",
         "expiration_date": "2020-02-14T20:35:14Z",
-        "expiration_date_parsed": "2020-02-14T20:35:14Z"
+        "expiration_date_in_time": "2020-02-14T20:35:14Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/in_google.in.json
+++ b/testdata/noterror/in_google.in.json
@@ -17,8 +17,11 @@
             "ns3.google.com"
         ],
         "created_date": "2005-02-14T20:35:14Z",
+        "created_date_parsed": "2005-02-14T20:35:14Z",
         "updated_date": "2019-08-08T18:39:47Z",
-        "expiration_date": "2020-02-14T20:35:14Z"
+        "updated_date_parsed": "2019-08-08T18:39:47Z",
+        "expiration_date": "2020-02-14T20:35:14Z",
+        "expiration_date_parsed": "2020-02-14T20:35:14Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/info_github.info.json
+++ b/testdata/noterror/info_github.info.json
@@ -18,8 +18,11 @@
             "ns.registar.ro"
         ],
         "created_date": "2014-01-05T12:18:22Z",
+        "created_date_parsed": "2014-01-05T12:18:22Z",
         "updated_date": "2019-01-06T12:04:19Z",
-        "expiration_date": "2020-01-05T12:18:22Z"
+        "updated_date_parsed": "2019-01-06T12:04:19Z",
+        "expiration_date": "2020-01-05T12:18:22Z",
+        "expiration_date_parsed": "2020-01-05T12:18:22Z"
     },
     "registrar": {
         "id": "146",

--- a/testdata/noterror/info_github.info.json
+++ b/testdata/noterror/info_github.info.json
@@ -18,11 +18,11 @@
             "ns.registar.ro"
         ],
         "created_date": "2014-01-05T12:18:22Z",
-        "created_date_parsed": "2014-01-05T12:18:22Z",
+        "created_date_in_time": "2014-01-05T12:18:22Z",
         "updated_date": "2019-01-06T12:04:19Z",
-        "updated_date_parsed": "2019-01-06T12:04:19Z",
+        "updated_date_in_time": "2019-01-06T12:04:19Z",
         "expiration_date": "2020-01-05T12:18:22Z",
-        "expiration_date_parsed": "2020-01-05T12:18:22Z"
+        "expiration_date_in_time": "2020-01-05T12:18:22Z"
     },
     "registrar": {
         "id": "146",

--- a/testdata/noterror/info_west.info.json
+++ b/testdata/noterror/info_west.info.json
@@ -15,8 +15,11 @@
             "dns3.ipmanagerinc.net"
         ],
         "created_date": "2001-07-31T21:14:42Z",
+        "created_date_parsed": "2001-07-31T21:14:42Z",
         "updated_date": "2019-09-20T00:17:40Z",
-        "expiration_date": "2020-07-31T21:14:42Z"
+        "updated_date_parsed": "2019-09-20T00:17:40Z",
+        "expiration_date": "2020-07-31T21:14:42Z",
+        "expiration_date_parsed": "2020-07-31T21:14:42Z"
     },
     "registrar": {
         "id": "151",

--- a/testdata/noterror/info_west.info.json
+++ b/testdata/noterror/info_west.info.json
@@ -15,11 +15,11 @@
             "dns3.ipmanagerinc.net"
         ],
         "created_date": "2001-07-31T21:14:42Z",
-        "created_date_parsed": "2001-07-31T21:14:42Z",
+        "created_date_in_time": "2001-07-31T21:14:42Z",
         "updated_date": "2019-09-20T00:17:40Z",
-        "updated_date_parsed": "2019-09-20T00:17:40Z",
+        "updated_date_in_time": "2019-09-20T00:17:40Z",
         "expiration_date": "2020-07-31T21:14:42Z",
-        "expiration_date_parsed": "2020-07-31T21:14:42Z"
+        "expiration_date_in_time": "2020-07-31T21:14:42Z"
     },
     "registrar": {
         "id": "151",

--- a/testdata/noterror/int_esa.int.json
+++ b/testdata/noterror/int_esa.int.json
@@ -13,7 +13,9 @@
             "dns6.esa.int"
         ],
         "created_date": "1996-08-23",
-        "updated_date": "2009-03-19"
+        "created_date_parsed": "1996-08-23T00:00:00Z",
+        "updated_date": "2009-03-19",
+        "updated_date_parsed": "2009-03-19T00:00:00Z"
     },
     "registrant": {
         "organization": "European Space Agency (ESA)",

--- a/testdata/noterror/int_esa.int.json
+++ b/testdata/noterror/int_esa.int.json
@@ -13,9 +13,9 @@
             "dns6.esa.int"
         ],
         "created_date": "1996-08-23",
-        "created_date_parsed": "1996-08-23T00:00:00Z",
+        "created_date_in_time": "1996-08-23T00:00:00Z",
         "updated_date": "2009-03-19",
-        "updated_date_parsed": "2009-03-19T00:00:00Z"
+        "updated_date_in_time": "2009-03-19T00:00:00Z"
     },
     "registrant": {
         "organization": "European Space Agency (ESA)",

--- a/testdata/noterror/int_wto.int.json
+++ b/testdata/noterror/int_wto.int.json
@@ -9,9 +9,9 @@
             "ns1.gva.ch.colt.net"
         ],
         "created_date": "2001-09-10",
-        "created_date_parsed": "2001-09-10T00:00:00Z",
+        "created_date_in_time": "2001-09-10T00:00:00Z",
         "updated_date": "2019-02-21",
-        "updated_date_parsed": "2019-02-21T00:00:00Z"
+        "updated_date_in_time": "2019-02-21T00:00:00Z"
     },
     "registrant": {
         "organization": "World Trade Organization",

--- a/testdata/noterror/int_wto.int.json
+++ b/testdata/noterror/int_wto.int.json
@@ -9,7 +9,9 @@
             "ns1.gva.ch.colt.net"
         ],
         "created_date": "2001-09-10",
-        "updated_date": "2019-02-21"
+        "created_date_parsed": "2001-09-10T00:00:00Z",
+        "updated_date": "2019-02-21",
+        "updated_date_parsed": "2019-02-21T00:00:00Z"
     },
     "registrant": {
         "organization": "World Trade Organization",

--- a/testdata/noterror/io_golang.io.json
+++ b/testdata/noterror/io_golang.io.json
@@ -14,8 +14,11 @@
             "ns103.ovh.net"
         ],
         "created_date": "2013-01-24T18:29:21Z",
+        "created_date_parsed": "2013-01-24T18:29:21Z",
         "updated_date": "2019-01-17T08:47:20Z",
-        "expiration_date": "2020-01-24T18:29:21Z"
+        "updated_date_parsed": "2019-01-17T08:47:20Z",
+        "expiration_date": "2020-01-24T18:29:21Z",
+        "expiration_date_parsed": "2020-01-24T18:29:21Z"
     },
     "registrar": {
         "id": "81",

--- a/testdata/noterror/io_golang.io.json
+++ b/testdata/noterror/io_golang.io.json
@@ -14,11 +14,11 @@
             "ns103.ovh.net"
         ],
         "created_date": "2013-01-24T18:29:21Z",
-        "created_date_parsed": "2013-01-24T18:29:21Z",
+        "created_date_in_time": "2013-01-24T18:29:21Z",
         "updated_date": "2019-01-17T08:47:20Z",
-        "updated_date_parsed": "2019-01-17T08:47:20Z",
+        "updated_date_in_time": "2019-01-17T08:47:20Z",
         "expiration_date": "2020-01-24T18:29:21Z",
-        "expiration_date_parsed": "2020-01-24T18:29:21Z"
+        "expiration_date_in_time": "2020-01-24T18:29:21Z"
     },
     "registrar": {
         "id": "81",

--- a/testdata/noterror/ir_git.ir.json
+++ b/testdata/noterror/ir_git.ir.json
@@ -9,9 +9,9 @@
             "ns2.git.ir"
         ],
         "updated_date": "2019-03-06",
-        "updated_date_parsed": "2019-03-06T00:00:00Z",
+        "updated_date_in_time": "2019-03-06T00:00:00Z",
         "expiration_date": "2023-10-16",
-        "expiration_date_parsed": "2023-10-16T00:00:00Z"
+        "expiration_date_in_time": "2023-10-16T00:00:00Z"
     },
     "registrant": {
         "id": "as10780-irnic",

--- a/testdata/noterror/ir_git.ir.json
+++ b/testdata/noterror/ir_git.ir.json
@@ -9,7 +9,9 @@
             "ns2.git.ir"
         ],
         "updated_date": "2019-03-06",
-        "expiration_date": "2023-10-16"
+        "updated_date_parsed": "2019-03-06T00:00:00Z",
+        "expiration_date": "2023-10-16",
+        "expiration_date_parsed": "2023-10-16T00:00:00Z"
     },
     "registrant": {
         "id": "as10780-irnic",

--- a/testdata/noterror/ir_google.ir.json
+++ b/testdata/noterror/ir_google.ir.json
@@ -11,7 +11,9 @@
             "ns4.googledomains.com"
         ],
         "updated_date": "2019-11-07",
-        "expiration_date": "2020-12-22"
+        "updated_date_parsed": "2019-11-07T00:00:00Z",
+        "expiration_date": "2020-12-22",
+        "expiration_date_parsed": "2020-12-22T00:00:00Z"
     },
     "registrant": {
         "id": "go438-irnic",

--- a/testdata/noterror/ir_google.ir.json
+++ b/testdata/noterror/ir_google.ir.json
@@ -11,9 +11,9 @@
             "ns4.googledomains.com"
         ],
         "updated_date": "2019-11-07",
-        "updated_date_parsed": "2019-11-07T00:00:00Z",
+        "updated_date_in_time": "2019-11-07T00:00:00Z",
         "expiration_date": "2020-12-22",
-        "expiration_date_parsed": "2020-12-22T00:00:00Z"
+        "expiration_date_in_time": "2020-12-22T00:00:00Z"
     },
     "registrant": {
         "id": "go438-irnic",

--- a/testdata/noterror/it_git.it.json
+++ b/testdata/noterror/it_git.it.json
@@ -12,8 +12,11 @@
             "ns2.parkingcrew.net"
         ],
         "created_date": "2018-08-28 09:00:00",
+        "created_date_parsed": "2018-08-28T09:00:00Z",
         "updated_date": "2019-09-13 00:43:43",
-        "expiration_date": "2020-08-28"
+        "updated_date_parsed": "2019-09-13T00:43:43Z",
+        "expiration_date": "2020-08-28",
+        "expiration_date_parsed": "2020-08-28T00:00:00Z"
     },
     "registrar": {
         "name": "AM-REG",

--- a/testdata/noterror/it_git.it.json
+++ b/testdata/noterror/it_git.it.json
@@ -12,11 +12,11 @@
             "ns2.parkingcrew.net"
         ],
         "created_date": "2018-08-28 09:00:00",
-        "created_date_parsed": "2018-08-28T09:00:00Z",
+        "created_date_in_time": "2018-08-28T09:00:00Z",
         "updated_date": "2019-09-13 00:43:43",
-        "updated_date_parsed": "2019-09-13T00:43:43Z",
+        "updated_date_in_time": "2019-09-13T00:43:43Z",
         "expiration_date": "2020-08-28",
-        "expiration_date_parsed": "2020-08-28T00:00:00Z"
+        "expiration_date_in_time": "2020-08-28T00:00:00Z"
     },
     "registrar": {
         "name": "AM-REG",

--- a/testdata/noterror/it_google.it.json
+++ b/testdata/noterror/it_google.it.json
@@ -14,11 +14,11 @@
             "ns4.google.com"
         ],
         "created_date": "1999-12-10 00:00:00",
-        "created_date_parsed": "1999-12-10T00:00:00Z",
+        "created_date_in_time": "1999-12-10T00:00:00Z",
         "updated_date": "2019-05-07 01:04:50",
-        "updated_date_parsed": "2019-05-07T01:04:50Z",
+        "updated_date_in_time": "2019-05-07T01:04:50Z",
         "expiration_date": "2020-04-21",
-        "expiration_date_parsed": "2020-04-21T00:00:00Z"
+        "expiration_date_in_time": "2020-04-21T00:00:00Z"
     },
     "registrar": {
         "name": "MARKMONITOR-REG",

--- a/testdata/noterror/it_google.it.json
+++ b/testdata/noterror/it_google.it.json
@@ -14,8 +14,11 @@
             "ns4.google.com"
         ],
         "created_date": "1999-12-10 00:00:00",
+        "created_date_parsed": "1999-12-10T00:00:00Z",
         "updated_date": "2019-05-07 01:04:50",
-        "expiration_date": "2020-04-21"
+        "updated_date_parsed": "2019-05-07T01:04:50Z",
+        "expiration_date": "2020-04-21",
+        "expiration_date_parsed": "2020-04-21T00:00:00Z"
     },
     "registrar": {
         "name": "MARKMONITOR-REG",

--- a/testdata/noterror/jobs_google.jobs.json
+++ b/testdata/noterror/jobs_google.jobs.json
@@ -16,11 +16,11 @@
             "ns2.google.com"
         ],
         "created_date": "2005-09-15T04:00:00Z",
-        "created_date_parsed": "2005-09-15T04:00:00Z",
+        "created_date_in_time": "2005-09-15T04:00:00Z",
         "updated_date": "2019-08-14T09:31:37Z",
-        "updated_date_parsed": "2019-08-14T09:31:37Z",
+        "updated_date_in_time": "2019-08-14T09:31:37Z",
         "expiration_date": "2020-09-15T04:00:00Z",
-        "expiration_date_parsed": "2020-09-15T04:00:00Z"
+        "expiration_date_in_time": "2020-09-15T04:00:00Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/jobs_google.jobs.json
+++ b/testdata/noterror/jobs_google.jobs.json
@@ -16,8 +16,11 @@
             "ns2.google.com"
         ],
         "created_date": "2005-09-15T04:00:00Z",
+        "created_date_parsed": "2005-09-15T04:00:00Z",
         "updated_date": "2019-08-14T09:31:37Z",
-        "expiration_date": "2020-09-15T04:00:00Z"
+        "updated_date_parsed": "2019-08-14T09:31:37Z",
+        "expiration_date": "2020-09-15T04:00:00Z",
+        "expiration_date_parsed": "2020-09-15T04:00:00Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/jobs_ybs.jobs.json
+++ b/testdata/noterror/jobs_ybs.jobs.json
@@ -14,8 +14,11 @@
             "ns1.ukfast.co.uk"
         ],
         "created_date": "2008-11-13T12:41:59Z",
+        "created_date_parsed": "2008-11-13T12:41:59Z",
         "updated_date": "2018-01-27T12:16:12Z",
-        "expiration_date": "2019-11-13T12:41:59Z"
+        "updated_date_parsed": "2018-01-27T12:16:12Z",
+        "expiration_date": "2019-11-13T12:41:59Z",
+        "expiration_date_parsed": "2019-11-13T12:41:59Z"
     },
     "registrar": {
         "id": "85",

--- a/testdata/noterror/jobs_ybs.jobs.json
+++ b/testdata/noterror/jobs_ybs.jobs.json
@@ -14,11 +14,11 @@
             "ns1.ukfast.co.uk"
         ],
         "created_date": "2008-11-13T12:41:59Z",
-        "created_date_parsed": "2008-11-13T12:41:59Z",
+        "created_date_in_time": "2008-11-13T12:41:59Z",
         "updated_date": "2018-01-27T12:16:12Z",
-        "updated_date_parsed": "2018-01-27T12:16:12Z",
+        "updated_date_in_time": "2018-01-27T12:16:12Z",
         "expiration_date": "2019-11-13T12:41:59Z",
-        "expiration_date_parsed": "2019-11-13T12:41:59Z"
+        "expiration_date_in_time": "2019-11-13T12:41:59Z"
     },
     "registrar": {
         "id": "85",

--- a/testdata/noterror/kr_git.kr.json
+++ b/testdata/noterror/kr_git.kr.json
@@ -12,11 +12,11 @@
             "ns2.parkingcrew.net"
         ],
         "created_date": "2012. 05. 19.",
-        "created_date_parsed": "2012-05-19T00:00:00Z",
+        "created_date_in_time": "2012-05-19T00:00:00Z",
         "updated_date": "2017. 10. 17.",
-        "updated_date_parsed": "2017-10-17T00:00:00Z",
+        "updated_date_in_time": "2017-10-17T00:00:00Z",
         "expiration_date": "2020. 05. 19.",
-        "expiration_date_parsed": "2020-05-19T00:00:00Z"
+        "expiration_date_in_time": "2020-05-19T00:00:00Z"
     },
     "registrar": {
         "name": "Megazone(http://HOSTING.KR)"

--- a/testdata/noterror/kr_git.kr.json
+++ b/testdata/noterror/kr_git.kr.json
@@ -12,8 +12,11 @@
             "ns2.parkingcrew.net"
         ],
         "created_date": "2012. 05. 19.",
+        "created_date_parsed": "2012-05-19T00:00:00Z",
         "updated_date": "2017. 10. 17.",
-        "expiration_date": "2020. 05. 19."
+        "updated_date_parsed": "2017-10-17T00:00:00Z",
+        "expiration_date": "2020. 05. 19.",
+        "expiration_date_parsed": "2020-05-19T00:00:00Z"
     },
     "registrar": {
         "name": "Megazone(http://HOSTING.KR)"

--- a/testdata/noterror/kr_google.kr.json
+++ b/testdata/noterror/kr_google.kr.json
@@ -9,11 +9,11 @@
             "ns2.google.com"
         ],
         "created_date": "2007. 03. 02.",
-        "created_date_parsed": "2007-03-02T00:00:00Z",
+        "created_date_in_time": "2007-03-02T00:00:00Z",
         "updated_date": "2010. 10. 04.",
-        "updated_date_parsed": "2010-10-04T00:00:00Z",
+        "updated_date_in_time": "2010-10-04T00:00:00Z",
         "expiration_date": "2020. 03. 02.",
-        "expiration_date_parsed": "2020-03-02T00:00:00Z"
+        "expiration_date_in_time": "2020-03-02T00:00:00Z"
     },
     "registrar": {
         "name": "Whois Corp.(http://whois.co.kr)"

--- a/testdata/noterror/kr_google.kr.json
+++ b/testdata/noterror/kr_google.kr.json
@@ -9,8 +9,11 @@
             "ns2.google.com"
         ],
         "created_date": "2007. 03. 02.",
+        "created_date_parsed": "2007-03-02T00:00:00Z",
         "updated_date": "2010. 10. 04.",
-        "expiration_date": "2020. 03. 02."
+        "updated_date_parsed": "2010-10-04T00:00:00Z",
+        "expiration_date": "2020. 03. 02.",
+        "expiration_date_parsed": "2020-03-02T00:00:00Z"
     },
     "registrar": {
         "name": "Whois Corp.(http://whois.co.kr)"

--- a/testdata/noterror/la_git.la.json
+++ b/testdata/noterror/la_git.la.json
@@ -13,11 +13,11 @@
             "ivy.ns.cloudflare.com"
         ],
         "created_date": "2008-11-27T08:14:56.0Z",
-        "created_date_parsed": "2008-11-27T08:14:56Z",
+        "created_date_in_time": "2008-11-27T08:14:56Z",
         "updated_date": "2019-03-27T04:42:11.0Z",
-        "updated_date_parsed": "2019-03-27T04:42:11Z",
+        "updated_date_in_time": "2019-03-27T04:42:11Z",
         "expiration_date": "2019-11-27T23:59:59.0Z",
-        "expiration_date_parsed": "2019-11-27T23:59:59Z"
+        "expiration_date_in_time": "2019-11-27T23:59:59Z"
     },
     "registrar": {
         "name": "Name.com LLC",

--- a/testdata/noterror/la_git.la.json
+++ b/testdata/noterror/la_git.la.json
@@ -13,8 +13,11 @@
             "ivy.ns.cloudflare.com"
         ],
         "created_date": "2008-11-27T08:14:56.0Z",
+        "created_date_parsed": "2008-11-27T08:14:56Z",
         "updated_date": "2019-03-27T04:42:11.0Z",
-        "expiration_date": "2019-11-27T23:59:59.0Z"
+        "updated_date_parsed": "2019-03-27T04:42:11Z",
+        "expiration_date": "2019-11-27T23:59:59.0Z",
+        "expiration_date_parsed": "2019-11-27T23:59:59Z"
     },
     "registrar": {
         "name": "Name.com LLC",

--- a/testdata/noterror/la_google.la.json
+++ b/testdata/noterror/la_google.la.json
@@ -15,8 +15,11 @@
             "ns4.google.com"
         ],
         "created_date": "2002-07-18T01:00:00.0Z",
+        "created_date_parsed": "2002-07-18T01:00:00Z",
         "updated_date": "2019-06-17T16:18:05.0Z",
-        "expiration_date": "2020-07-18T23:59:59.0Z"
+        "updated_date_parsed": "2019-06-17T16:18:05Z",
+        "expiration_date": "2020-07-18T23:59:59.0Z",
+        "expiration_date_parsed": "2020-07-18T23:59:59Z"
     },
     "registrar": {
         "name": "TLD Registrar Solutions Ltd",

--- a/testdata/noterror/la_google.la.json
+++ b/testdata/noterror/la_google.la.json
@@ -15,11 +15,11 @@
             "ns4.google.com"
         ],
         "created_date": "2002-07-18T01:00:00.0Z",
-        "created_date_parsed": "2002-07-18T01:00:00Z",
+        "created_date_in_time": "2002-07-18T01:00:00Z",
         "updated_date": "2019-06-17T16:18:05.0Z",
-        "updated_date_parsed": "2019-06-17T16:18:05Z",
+        "updated_date_in_time": "2019-06-17T16:18:05Z",
         "expiration_date": "2020-07-18T23:59:59.0Z",
-        "expiration_date_parsed": "2020-07-18T23:59:59Z"
+        "expiration_date_in_time": "2020-07-18T23:59:59Z"
     },
     "registrar": {
         "name": "TLD Registrar Solutions Ltd",

--- a/testdata/noterror/london_google.london.json
+++ b/testdata/noterror/london_google.london.json
@@ -17,8 +17,11 @@
             "ns3.googledomains.com"
         ],
         "created_date": "2015-03-04T10:30:28Z",
+        "created_date_parsed": "2015-03-04T10:30:28Z",
         "updated_date": "2019-01-31T10:39:36Z",
-        "expiration_date": "2020-03-04T10:30:28Z"
+        "updated_date_parsed": "2019-01-31T10:39:36Z",
+        "expiration_date": "2020-03-04T10:30:28Z",
+        "expiration_date_parsed": "2020-03-04T10:30:28Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/london_google.london.json
+++ b/testdata/noterror/london_google.london.json
@@ -17,11 +17,11 @@
             "ns3.googledomains.com"
         ],
         "created_date": "2015-03-04T10:30:28Z",
-        "created_date_parsed": "2015-03-04T10:30:28Z",
+        "created_date_in_time": "2015-03-04T10:30:28Z",
         "updated_date": "2019-01-31T10:39:36Z",
-        "updated_date_parsed": "2019-01-31T10:39:36Z",
+        "updated_date_in_time": "2019-01-31T10:39:36Z",
         "expiration_date": "2020-03-04T10:30:28Z",
-        "expiration_date_parsed": "2020-03-04T10:30:28Z"
+        "expiration_date_in_time": "2020-03-04T10:30:28Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/london_lat.london.json
+++ b/testdata/noterror/london_lat.london.json
@@ -19,8 +19,11 @@
             "ns-1139.awsdns-14.org"
         ],
         "created_date": "2014-09-19T16:12:13Z",
+        "created_date_parsed": "2014-09-19T16:12:13Z",
         "updated_date": "2019-09-24T16:34:14Z",
-        "expiration_date": "2020-09-19T16:12:13Z"
+        "updated_date_parsed": "2019-09-24T16:34:14Z",
+        "expiration_date": "2020-09-19T16:12:13Z",
+        "expiration_date_parsed": "2020-09-19T16:12:13Z"
     },
     "registrar": {
         "id": "146",

--- a/testdata/noterror/london_lat.london.json
+++ b/testdata/noterror/london_lat.london.json
@@ -19,11 +19,11 @@
             "ns-1139.awsdns-14.org"
         ],
         "created_date": "2014-09-19T16:12:13Z",
-        "created_date_parsed": "2014-09-19T16:12:13Z",
+        "created_date_in_time": "2014-09-19T16:12:13Z",
         "updated_date": "2019-09-24T16:34:14Z",
-        "updated_date_parsed": "2019-09-24T16:34:14Z",
+        "updated_date_in_time": "2019-09-24T16:34:14Z",
         "expiration_date": "2020-09-19T16:12:13Z",
-        "expiration_date_parsed": "2020-09-19T16:12:13Z"
+        "expiration_date_in_time": "2020-09-19T16:12:13Z"
     },
     "registrar": {
         "id": "146",

--- a/testdata/noterror/love_get.love.json
+++ b/testdata/noterror/love_get.love.json
@@ -14,8 +14,11 @@
             "ns02.merchantlaw.com"
         ],
         "created_date": "2015-05-06T10:39:53.0Z",
+        "created_date_parsed": "2015-05-06T10:39:53Z",
         "updated_date": "2019-04-30T00:17:23.0Z",
-        "expiration_date": "2020-05-06T23:59:59.0Z"
+        "updated_date_parsed": "2019-04-30T00:17:23Z",
+        "expiration_date": "2020-05-06T23:59:59.0Z",
+        "expiration_date_parsed": "2020-05-06T23:59:59Z"
     },
     "registrar": {
         "id": "9999",

--- a/testdata/noterror/love_get.love.json
+++ b/testdata/noterror/love_get.love.json
@@ -14,11 +14,11 @@
             "ns02.merchantlaw.com"
         ],
         "created_date": "2015-05-06T10:39:53.0Z",
-        "created_date_parsed": "2015-05-06T10:39:53Z",
+        "created_date_in_time": "2015-05-06T10:39:53Z",
         "updated_date": "2019-04-30T00:17:23.0Z",
-        "updated_date_parsed": "2019-04-30T00:17:23Z",
+        "updated_date_in_time": "2019-04-30T00:17:23Z",
         "expiration_date": "2020-05-06T23:59:59.0Z",
-        "expiration_date_parsed": "2020-05-06T23:59:59Z"
+        "expiration_date_in_time": "2020-05-06T23:59:59Z"
     },
     "registrar": {
         "id": "9999",

--- a/testdata/noterror/love_iodp.love.json
+++ b/testdata/noterror/love_iodp.love.json
@@ -16,11 +16,11 @@
             "ns2.esm1066.sgded.com"
         ],
         "created_date": "2016-11-10T14:17:33.0Z",
-        "created_date_parsed": "2016-11-10T14:17:33Z",
+        "created_date_in_time": "2016-11-10T14:17:33Z",
         "updated_date": "2019-07-10T12:26:00.0Z",
-        "updated_date_parsed": "2019-07-10T12:26:00Z",
+        "updated_date_in_time": "2019-07-10T12:26:00Z",
         "expiration_date": "2020-11-10T23:59:59.0Z",
-        "expiration_date_parsed": "2020-11-10T23:59:59Z"
+        "expiration_date_in_time": "2020-11-10T23:59:59Z"
     },
     "registrar": {
         "id": "1390",

--- a/testdata/noterror/love_iodp.love.json
+++ b/testdata/noterror/love_iodp.love.json
@@ -16,8 +16,11 @@
             "ns2.esm1066.sgded.com"
         ],
         "created_date": "2016-11-10T14:17:33.0Z",
+        "created_date_parsed": "2016-11-10T14:17:33Z",
         "updated_date": "2019-07-10T12:26:00.0Z",
-        "expiration_date": "2020-11-10T23:59:59.0Z"
+        "updated_date_parsed": "2019-07-10T12:26:00Z",
+        "expiration_date": "2020-11-10T23:59:59.0Z",
+        "expiration_date_parsed": "2020-11-10T23:59:59Z"
     },
     "registrar": {
         "id": "1390",

--- a/testdata/noterror/me_github.me.json
+++ b/testdata/noterror/me_github.me.json
@@ -17,8 +17,11 @@
             "ns4.p16.dynect.net"
         ],
         "created_date": "2010-08-05T17:04:24Z",
+        "created_date_parsed": "2010-08-05T17:04:24Z",
         "updated_date": "2018-07-04T09:14:12Z",
-        "expiration_date": "2020-08-05T17:04:24Z"
+        "updated_date_parsed": "2018-07-04T09:14:12Z",
+        "expiration_date": "2020-08-05T17:04:24Z",
+        "expiration_date_parsed": "2020-08-05T17:04:24Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/me_github.me.json
+++ b/testdata/noterror/me_github.me.json
@@ -17,11 +17,11 @@
             "ns4.p16.dynect.net"
         ],
         "created_date": "2010-08-05T17:04:24Z",
-        "created_date_parsed": "2010-08-05T17:04:24Z",
+        "created_date_in_time": "2010-08-05T17:04:24Z",
         "updated_date": "2018-07-04T09:14:12Z",
-        "updated_date_parsed": "2018-07-04T09:14:12Z",
+        "updated_date_in_time": "2018-07-04T09:14:12Z",
         "expiration_date": "2020-08-05T17:04:24Z",
-        "expiration_date_parsed": "2020-08-05T17:04:24Z"
+        "expiration_date_in_time": "2020-08-05T17:04:24Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/me_google.me.json
+++ b/testdata/noterror/me_google.me.json
@@ -20,8 +20,11 @@
             "ns3.google.com"
         ],
         "created_date": "2008-06-13T17:17:40Z",
+        "created_date_parsed": "2008-06-13T17:17:40Z",
         "updated_date": "2019-05-12T09:35:12Z",
-        "expiration_date": "2020-06-13T17:17:40Z"
+        "updated_date_parsed": "2019-05-12T09:35:12Z",
+        "expiration_date": "2020-06-13T17:17:40Z",
+        "expiration_date_parsed": "2020-06-13T17:17:40Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/me_google.me.json
+++ b/testdata/noterror/me_google.me.json
@@ -20,11 +20,11 @@
             "ns3.google.com"
         ],
         "created_date": "2008-06-13T17:17:40Z",
-        "created_date_parsed": "2008-06-13T17:17:40Z",
+        "created_date_in_time": "2008-06-13T17:17:40Z",
         "updated_date": "2019-05-12T09:35:12Z",
-        "updated_date_parsed": "2019-05-12T09:35:12Z",
+        "updated_date_in_time": "2019-05-12T09:35:12Z",
         "expiration_date": "2020-06-13T17:17:40Z",
-        "expiration_date_parsed": "2020-06-13T17:17:40Z"
+        "expiration_date_in_time": "2020-06-13T17:17:40Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/mo_moo.mo.json
+++ b/testdata/noterror/mo_moo.mo.json
@@ -10,7 +10,9 @@
             "ns1.wordpress.com"
         ],
         "created_date": "2018-02-05 22:59:12.55172",
-        "expiration_date": "2021-02-05"
+        "created_date_parsed": "2018-02-05T22:59:12.55172Z",
+        "expiration_date": "2021-02-05",
+        "expiration_date_parsed": "2021-02-05T00:00:00Z"
     },
     "registrant": {
         "name": "陳秀霞",

--- a/testdata/noterror/mo_moo.mo.json
+++ b/testdata/noterror/mo_moo.mo.json
@@ -10,9 +10,9 @@
             "ns1.wordpress.com"
         ],
         "created_date": "2018-02-05 22:59:12.55172",
-        "created_date_parsed": "2018-02-05T22:59:12.55172Z",
+        "created_date_in_time": "2018-02-05T22:59:12.55172Z",
         "expiration_date": "2021-02-05",
-        "expiration_date_parsed": "2021-02-05T00:00:00Z"
+        "expiration_date_in_time": "2021-02-05T00:00:00Z"
     },
     "registrant": {
         "name": "陳秀霞",

--- a/testdata/noterror/mo_yp.mo.json
+++ b/testdata/noterror/mo_yp.mo.json
@@ -9,9 +9,9 @@
             "art.ns.cloudflare.com"
         ],
         "created_date": "2005-04-15 21:43:27",
-        "created_date_parsed": "2005-04-15T21:43:27Z",
+        "created_date_in_time": "2005-04-15T21:43:27Z",
         "expiration_date": "2020-11-02",
-        "expiration_date_parsed": "2020-11-02T00:00:00Z"
+        "expiration_date_in_time": "2020-11-02T00:00:00Z"
     },
     "registrant": {
         "name": "George Shew",

--- a/testdata/noterror/mo_yp.mo.json
+++ b/testdata/noterror/mo_yp.mo.json
@@ -9,7 +9,9 @@
             "art.ns.cloudflare.com"
         ],
         "created_date": "2005-04-15 21:43:27",
-        "expiration_date": "2020-11-02"
+        "created_date_parsed": "2005-04-15T21:43:27Z",
+        "expiration_date": "2020-11-02",
+        "expiration_date_parsed": "2020-11-02T00:00:00Z"
     },
     "registrant": {
         "name": "George Shew",

--- a/testdata/noterror/mobi_git.mobi.json
+++ b/testdata/noterror/mobi_git.mobi.json
@@ -15,11 +15,11 @@
             "ns2.parklogic.com"
         ],
         "created_date": "2015-05-19T03:25:15Z",
-        "created_date_parsed": "2015-05-19T03:25:15Z",
+        "created_date_in_time": "2015-05-19T03:25:15Z",
         "updated_date": "2019-08-25T04:21:56Z",
-        "updated_date_parsed": "2019-08-25T04:21:56Z",
+        "updated_date_in_time": "2019-08-25T04:21:56Z",
         "expiration_date": "2020-05-19T03:25:15Z",
-        "expiration_date_parsed": "2020-05-19T03:25:15Z"
+        "expiration_date_in_time": "2020-05-19T03:25:15Z"
     },
     "registrar": {
         "id": "600",

--- a/testdata/noterror/mobi_git.mobi.json
+++ b/testdata/noterror/mobi_git.mobi.json
@@ -15,8 +15,11 @@
             "ns2.parklogic.com"
         ],
         "created_date": "2015-05-19T03:25:15Z",
+        "created_date_parsed": "2015-05-19T03:25:15Z",
         "updated_date": "2019-08-25T04:21:56Z",
-        "expiration_date": "2020-05-19T03:25:15Z"
+        "updated_date_parsed": "2019-08-25T04:21:56Z",
+        "expiration_date": "2020-05-19T03:25:15Z",
+        "expiration_date_parsed": "2020-05-19T03:25:15Z"
     },
     "registrar": {
         "id": "600",

--- a/testdata/noterror/museum_google.museum.json
+++ b/testdata/noterror/museum_google.museum.json
@@ -16,8 +16,11 @@
             "ns5.inwx.net"
         ],
         "created_date": "2019-05-02T09:18:21Z",
+        "created_date_parsed": "2019-05-02T09:18:21Z",
         "updated_date": "2019-05-02T09:18:25Z",
-        "expiration_date": "2020-05-02T09:18:22Z"
+        "updated_date_parsed": "2019-05-02T09:18:25Z",
+        "expiration_date": "2020-05-02T09:18:22Z",
+        "expiration_date_parsed": "2020-05-02T09:18:22Z"
     },
     "registrar": {
         "id": "1420",

--- a/testdata/noterror/museum_google.museum.json
+++ b/testdata/noterror/museum_google.museum.json
@@ -16,11 +16,11 @@
             "ns5.inwx.net"
         ],
         "created_date": "2019-05-02T09:18:21Z",
-        "created_date_parsed": "2019-05-02T09:18:21Z",
+        "created_date_in_time": "2019-05-02T09:18:21Z",
         "updated_date": "2019-05-02T09:18:25Z",
-        "updated_date_parsed": "2019-05-02T09:18:25Z",
+        "updated_date_in_time": "2019-05-02T09:18:25Z",
         "expiration_date": "2020-05-02T09:18:22Z",
-        "expiration_date_parsed": "2020-05-02T09:18:22Z"
+        "expiration_date_in_time": "2020-05-02T09:18:22Z"
     },
     "registrar": {
         "id": "1420",

--- a/testdata/noterror/museum_sea.museum.json
+++ b/testdata/noterror/museum_sea.museum.json
@@ -15,11 +15,11 @@
             "ns03.trademarkarea.com"
         ],
         "created_date": "2018-10-23T14:02:32Z",
-        "created_date_parsed": "2018-10-23T14:02:32Z",
+        "created_date_in_time": "2018-10-23T14:02:32Z",
         "updated_date": "2019-04-30T07:34:28Z",
-        "updated_date_parsed": "2019-04-30T07:34:28Z",
+        "updated_date_in_time": "2019-04-30T07:34:28Z",
         "expiration_date": "2019-10-23T14:02:33Z",
-        "expiration_date_parsed": "2019-10-23T14:02:33Z"
+        "expiration_date_in_time": "2019-10-23T14:02:33Z"
     },
     "registrar": {
         "id": "111",

--- a/testdata/noterror/museum_sea.museum.json
+++ b/testdata/noterror/museum_sea.museum.json
@@ -15,8 +15,11 @@
             "ns03.trademarkarea.com"
         ],
         "created_date": "2018-10-23T14:02:32Z",
+        "created_date_parsed": "2018-10-23T14:02:32Z",
         "updated_date": "2019-04-30T07:34:28Z",
-        "expiration_date": "2019-10-23T14:02:33Z"
+        "updated_date_parsed": "2019-04-30T07:34:28Z",
+        "expiration_date": "2019-10-23T14:02:33Z",
+        "expiration_date_parsed": "2019-10-23T14:02:33Z"
     },
     "registrar": {
         "id": "111",

--- a/testdata/noterror/net_gandi.net.json
+++ b/testdata/noterror/net_gandi.net.json
@@ -20,8 +20,11 @@
             "dns6.gandi.net"
         ],
         "created_date": "1999-05-21T10:09:21Z",
+        "created_date_parsed": "1999-05-21T10:09:21Z",
         "updated_date": "2019-02-07T09:22:28Z",
-        "expiration_date": "2025-05-21T14:09:56Z"
+        "updated_date_parsed": "2019-02-07T09:22:28Z",
+        "expiration_date": "2025-05-21T14:09:56Z",
+        "expiration_date_parsed": "2025-05-21T14:09:56Z"
     },
     "registrar": {
         "id": "81",

--- a/testdata/noterror/net_gandi.net.json
+++ b/testdata/noterror/net_gandi.net.json
@@ -20,11 +20,11 @@
             "dns6.gandi.net"
         ],
         "created_date": "1999-05-21T10:09:21Z",
-        "created_date_parsed": "1999-05-21T10:09:21Z",
+        "created_date_in_time": "1999-05-21T10:09:21Z",
         "updated_date": "2019-02-07T09:22:28Z",
-        "updated_date_parsed": "2019-02-07T09:22:28Z",
+        "updated_date_in_time": "2019-02-07T09:22:28Z",
         "expiration_date": "2025-05-21T14:09:56Z",
-        "expiration_date_parsed": "2025-05-21T14:09:56Z"
+        "expiration_date_in_time": "2025-05-21T14:09:56Z"
     },
     "registrar": {
         "id": "81",

--- a/testdata/noterror/net_he.net.json
+++ b/testdata/noterror/net_he.net.json
@@ -17,11 +17,11 @@
             "ns5.he.net"
         ],
         "created_date": "1995-07-31T04:00:00Z",
-        "created_date_parsed": "1995-07-31T04:00:00Z",
+        "created_date_in_time": "1995-07-31T04:00:00Z",
         "updated_date": "2019-07-30T19:17:40Z",
-        "updated_date_parsed": "2019-07-30T19:17:40Z",
+        "updated_date_in_time": "2019-07-30T19:17:40Z",
         "expiration_date": "2029-07-30T04:00:00Z",
-        "expiration_date_parsed": "2029-07-30T04:00:00Z"
+        "expiration_date_in_time": "2029-07-30T04:00:00Z"
     },
     "registrar": {
         "id": "2",

--- a/testdata/noterror/net_he.net.json
+++ b/testdata/noterror/net_he.net.json
@@ -17,8 +17,11 @@
             "ns5.he.net"
         ],
         "created_date": "1995-07-31T04:00:00Z",
+        "created_date_parsed": "1995-07-31T04:00:00Z",
         "updated_date": "2019-07-30T19:17:40Z",
-        "expiration_date": "2029-07-30T04:00:00Z"
+        "updated_date_parsed": "2019-07-30T19:17:40Z",
+        "expiration_date": "2029-07-30T04:00:00Z",
+        "expiration_date_parsed": "2029-07-30T04:00:00Z"
     },
     "registrar": {
         "id": "2",

--- a/testdata/noterror/net_hexonet.net.json
+++ b/testdata/noterror/net_hexonet.net.json
@@ -15,8 +15,11 @@
             "ns3012.hexonet.net"
         ],
         "created_date": "2001-01-20T13:40:16Z",
+        "created_date_parsed": "2001-01-20T13:40:16Z",
         "updated_date": "2017-02-28T09:53:46Z",
-        "expiration_date": "2021-01-20T13:40:16Z"
+        "updated_date_parsed": "2017-02-28T09:53:46Z",
+        "expiration_date": "2021-01-20T13:40:16Z",
+        "expiration_date_parsed": "2021-01-20T13:40:16Z"
     },
     "registrar": {
         "id": "1387",

--- a/testdata/noterror/net_hexonet.net.json
+++ b/testdata/noterror/net_hexonet.net.json
@@ -15,11 +15,11 @@
             "ns3012.hexonet.net"
         ],
         "created_date": "2001-01-20T13:40:16Z",
-        "created_date_parsed": "2001-01-20T13:40:16Z",
+        "created_date_in_time": "2001-01-20T13:40:16Z",
         "updated_date": "2017-02-28T09:53:46Z",
-        "updated_date_parsed": "2017-02-28T09:53:46Z",
+        "updated_date_in_time": "2017-02-28T09:53:46Z",
         "expiration_date": "2021-01-20T13:40:16Z",
-        "expiration_date_parsed": "2021-01-20T13:40:16Z"
+        "expiration_date_in_time": "2021-01-20T13:40:16Z"
     },
     "registrar": {
         "id": "1387",

--- a/testdata/noterror/nz_gre.nz.json
+++ b/testdata/noterror/nz_gre.nz.json
@@ -13,7 +13,7 @@
             "ns-104-b.gandi.net"
         ],
         "updated_date": "2019-01-02T04:55:30+13:00",
-        "updated_date_parsed": "2019-01-02T04:55:30+13:00"
+        "updated_date_in_time": "2019-01-02T04:55:30+13:00"
     },
     "registrar": {
         "name": "Gandi",

--- a/testdata/noterror/nz_gre.nz.json
+++ b/testdata/noterror/nz_gre.nz.json
@@ -12,7 +12,8 @@
             "ns-110-a.gandi.net",
             "ns-104-b.gandi.net"
         ],
-        "updated_date": "2019-01-02T04:55:30+13:00"
+        "updated_date": "2019-01-02T04:55:30+13:00",
+        "updated_date_parsed": "2019-01-02T04:55:30+13:00"
     },
     "registrar": {
         "name": "Gandi",

--- a/testdata/noterror/nz_vote.nz.json
+++ b/testdata/noterror/nz_vote.nz.json
@@ -14,7 +14,7 @@
             "ns2.catalyst.net.nz"
         ],
         "updated_date": "2019-10-12T23:35:35+13:00",
-        "updated_date_parsed": "2019-10-12T23:35:35+13:00"
+        "updated_date_in_time": "2019-10-12T23:35:35+13:00"
     },
     "registrar": {
         "name": "Catalyst DNS Administrator",

--- a/testdata/noterror/nz_vote.nz.json
+++ b/testdata/noterror/nz_vote.nz.json
@@ -13,7 +13,8 @@
             "ns1.catalyst.net.nz",
             "ns2.catalyst.net.nz"
         ],
-        "updated_date": "2019-10-12T23:35:35+13:00"
+        "updated_date": "2019-10-12T23:35:35+13:00",
+        "updated_date_parsed": "2019-10-12T23:35:35+13:00"
     },
     "registrar": {
         "name": "Catalyst DNS Administrator",

--- a/testdata/noterror/org_apache.org.json
+++ b/testdata/noterror/org_apache.org.json
@@ -18,11 +18,11 @@
             "ns4.no-ip.com"
         ],
         "created_date": "1995-04-11T04:00:00.00Z",
-        "created_date_parsed": "1995-04-11T04:00:00Z",
+        "created_date_in_time": "1995-04-11T04:00:00Z",
         "updated_date": "2018-09-25T13:18:21.00Z",
-        "updated_date_parsed": "2018-09-25T13:18:21Z",
+        "updated_date_in_time": "2018-09-25T13:18:21Z",
         "expiration_date": "2022-04-12T04:00:00.00Z",
-        "expiration_date_parsed": "2022-04-12T04:00:00Z"
+        "expiration_date_in_time": "2022-04-12T04:00:00Z"
     },
     "registrar": {
         "id": "1068",

--- a/testdata/noterror/org_apache.org.json
+++ b/testdata/noterror/org_apache.org.json
@@ -18,8 +18,11 @@
             "ns4.no-ip.com"
         ],
         "created_date": "1995-04-11T04:00:00.00Z",
+        "created_date_parsed": "1995-04-11T04:00:00Z",
         "updated_date": "2018-09-25T13:18:21.00Z",
-        "expiration_date": "2022-04-12T04:00:00.00Z"
+        "updated_date_parsed": "2018-09-25T13:18:21Z",
+        "expiration_date": "2022-04-12T04:00:00.00Z",
+        "expiration_date_parsed": "2022-04-12T04:00:00Z"
     },
     "registrar": {
         "id": "1068",

--- a/testdata/noterror/org_github.org.json
+++ b/testdata/noterror/org_github.org.json
@@ -16,11 +16,11 @@
             "ns4.dnsimple.com"
         ],
         "created_date": "2008-02-09T02:07:00.00Z",
-        "created_date_parsed": "2008-02-09T02:07:00Z",
+        "created_date_in_time": "2008-02-09T02:07:00Z",
         "updated_date": "2019-01-11T08:26:28.00Z",
-        "updated_date_parsed": "2019-01-11T08:26:28Z",
+        "updated_date_in_time": "2019-01-11T08:26:28Z",
         "expiration_date": "2020-02-09T02:07:00.00Z",
-        "expiration_date_parsed": "2020-02-09T02:07:00Z"
+        "expiration_date_in_time": "2020-02-09T02:07:00Z"
     },
     "registrar": {
         "id": "48",

--- a/testdata/noterror/org_github.org.json
+++ b/testdata/noterror/org_github.org.json
@@ -16,8 +16,11 @@
             "ns4.dnsimple.com"
         ],
         "created_date": "2008-02-09T02:07:00.00Z",
+        "created_date_parsed": "2008-02-09T02:07:00Z",
         "updated_date": "2019-01-11T08:26:28.00Z",
-        "expiration_date": "2020-02-09T02:07:00.00Z"
+        "updated_date_parsed": "2019-01-11T08:26:28Z",
+        "expiration_date": "2020-02-09T02:07:00.00Z",
+        "expiration_date_parsed": "2020-02-09T02:07:00Z"
     },
     "registrar": {
         "id": "48",

--- a/testdata/noterror/pm_git.pm.json
+++ b/testdata/noterror/pm_git.pm.json
@@ -12,8 +12,11 @@
             "ns2.srna.sk"
         ],
         "created_date": "2013-07-18T16:17:05Z",
+        "created_date_parsed": "2013-07-18T16:17:05Z",
         "updated_date": "2019-06-12T07:35:08Z",
-        "expiration_date": "2020-07-18T16:17:05Z"
+        "updated_date_parsed": "2019-06-12T07:35:08Z",
+        "expiration_date": "2020-07-18T16:17:05Z",
+        "expiration_date_parsed": "2020-07-18T16:17:05Z"
     },
     "registrar": {
         "name": "GRANSY s.r.o.",

--- a/testdata/noterror/pm_git.pm.json
+++ b/testdata/noterror/pm_git.pm.json
@@ -12,11 +12,11 @@
             "ns2.srna.sk"
         ],
         "created_date": "2013-07-18T16:17:05Z",
-        "created_date_parsed": "2013-07-18T16:17:05Z",
+        "created_date_in_time": "2013-07-18T16:17:05Z",
         "updated_date": "2019-06-12T07:35:08Z",
-        "updated_date_parsed": "2019-06-12T07:35:08Z",
+        "updated_date_in_time": "2019-06-12T07:35:08Z",
         "expiration_date": "2020-07-18T16:17:05Z",
-        "expiration_date_parsed": "2020-07-18T16:17:05Z"
+        "expiration_date_in_time": "2020-07-18T16:17:05Z"
     },
     "registrar": {
         "name": "GRANSY s.r.o.",

--- a/testdata/noterror/pm_google.pm.json
+++ b/testdata/noterror/pm_google.pm.json
@@ -12,11 +12,11 @@
             "ns3.markmonitor.com"
         ],
         "created_date": "2011-12-06T09:12:15Z",
-        "created_date_parsed": "2011-12-06T09:12:15Z",
+        "created_date_in_time": "2011-12-06T09:12:15Z",
         "updated_date": "2019-01-14T10:32:20Z",
-        "updated_date_parsed": "2019-01-14T10:32:20Z",
+        "updated_date_in_time": "2019-01-14T10:32:20Z",
         "expiration_date": "2020-02-15T19:06:33Z",
-        "expiration_date_parsed": "2020-02-15T19:06:33Z"
+        "expiration_date_in_time": "2020-02-15T19:06:33Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/pm_google.pm.json
+++ b/testdata/noterror/pm_google.pm.json
@@ -12,8 +12,11 @@
             "ns3.markmonitor.com"
         ],
         "created_date": "2011-12-06T09:12:15Z",
+        "created_date_parsed": "2011-12-06T09:12:15Z",
         "updated_date": "2019-01-14T10:32:20Z",
-        "expiration_date": "2020-02-15T19:06:33Z"
+        "updated_date_parsed": "2019-01-14T10:32:20Z",
+        "expiration_date": "2020-02-15T19:06:33Z",
+        "expiration_date_parsed": "2020-02-15T19:06:33Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/re_git.re.json
+++ b/testdata/noterror/re_git.re.json
@@ -12,11 +12,11 @@
             "dns2.yandex.net"
         ],
         "created_date": "2018-03-13T18:39:24Z",
-        "created_date_parsed": "2018-03-13T18:39:24Z",
+        "created_date_in_time": "2018-03-13T18:39:24Z",
         "updated_date": "2019-06-21T07:43:29Z",
-        "updated_date_parsed": "2019-06-21T07:43:29Z",
+        "updated_date_in_time": "2019-06-21T07:43:29Z",
         "expiration_date": "2022-03-13T18:39:24Z",
-        "expiration_date_parsed": "2022-03-13T18:39:24Z"
+        "expiration_date_in_time": "2022-03-13T18:39:24Z"
     },
     "registrar": {
         "name": "TLD Registrar Solutions Ltd",

--- a/testdata/noterror/re_git.re.json
+++ b/testdata/noterror/re_git.re.json
@@ -12,8 +12,11 @@
             "dns2.yandex.net"
         ],
         "created_date": "2018-03-13T18:39:24Z",
+        "created_date_parsed": "2018-03-13T18:39:24Z",
         "updated_date": "2019-06-21T07:43:29Z",
-        "expiration_date": "2022-03-13T18:39:24Z"
+        "updated_date_parsed": "2019-06-21T07:43:29Z",
+        "expiration_date": "2022-03-13T18:39:24Z",
+        "expiration_date_parsed": "2022-03-13T18:39:24Z"
     },
     "registrar": {
         "name": "TLD Registrar Solutions Ltd",

--- a/testdata/noterror/re_google.re.json
+++ b/testdata/noterror/re_google.re.json
@@ -14,11 +14,11 @@
             "ns4.google.com"
         ],
         "created_date": "2008-11-19T09:40:52Z",
-        "created_date_parsed": "2008-11-19T09:40:52Z",
+        "created_date_in_time": "2008-11-19T09:40:52Z",
         "updated_date": "2019-07-01T09:33:52Z",
-        "updated_date_parsed": "2019-07-01T09:33:52Z",
+        "updated_date_in_time": "2019-07-01T09:33:52Z",
         "expiration_date": "2020-08-02T23:15:21Z",
-        "expiration_date_parsed": "2020-08-02T23:15:21Z"
+        "expiration_date_in_time": "2020-08-02T23:15:21Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/re_google.re.json
+++ b/testdata/noterror/re_google.re.json
@@ -14,8 +14,11 @@
             "ns4.google.com"
         ],
         "created_date": "2008-11-19T09:40:52Z",
+        "created_date_parsed": "2008-11-19T09:40:52Z",
         "updated_date": "2019-07-01T09:33:52Z",
-        "expiration_date": "2020-08-02T23:15:21Z"
+        "updated_date_parsed": "2019-07-01T09:33:52Z",
+        "expiration_date": "2020-08-02T23:15:21Z",
+        "expiration_date_parsed": "2020-08-02T23:15:21Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/ro_git.ro.json
+++ b/testdata/noterror/ro_git.ro.json
@@ -12,7 +12,9 @@
             "b.ns.ro"
         ],
         "created_date": "2019-01-04",
-        "expiration_date": "2020-01-04"
+        "created_date_parsed": "2019-01-04T00:00:00Z",
+        "expiration_date": "2020-01-04",
+        "expiration_date_parsed": "2020-01-04T00:00:00Z"
     },
     "registrar": {
         "name": "NShost SRL",

--- a/testdata/noterror/ro_git.ro.json
+++ b/testdata/noterror/ro_git.ro.json
@@ -12,9 +12,9 @@
             "b.ns.ro"
         ],
         "created_date": "2019-01-04",
-        "created_date_parsed": "2019-01-04T00:00:00Z",
+        "created_date_in_time": "2019-01-04T00:00:00Z",
         "expiration_date": "2020-01-04",
-        "expiration_date_parsed": "2020-01-04T00:00:00Z"
+        "expiration_date_in_time": "2020-01-04T00:00:00Z"
     },
     "registrar": {
         "name": "NShost SRL",

--- a/testdata/noterror/ro_google.ro.json
+++ b/testdata/noterror/ro_google.ro.json
@@ -14,9 +14,9 @@
             "ns4.google.com"
         ],
         "created_date": "2000-07-17",
-        "created_date_parsed": "2000-07-17T00:00:00Z",
+        "created_date_in_time": "2000-07-17T00:00:00Z",
         "expiration_date": "2020-09-16",
-        "expiration_date_parsed": "2020-09-16T00:00:00Z"
+        "expiration_date_in_time": "2020-09-16T00:00:00Z"
     },
     "registrar": {
         "name": "MarkMonitor Inc.",

--- a/testdata/noterror/ro_google.ro.json
+++ b/testdata/noterror/ro_google.ro.json
@@ -14,7 +14,9 @@
             "ns4.google.com"
         ],
         "created_date": "2000-07-17",
-        "expiration_date": "2020-09-16"
+        "created_date_parsed": "2000-07-17T00:00:00Z",
+        "expiration_date": "2020-09-16",
+        "expiration_date_parsed": "2020-09-16T00:00:00Z"
     },
     "registrar": {
         "name": "MarkMonitor Inc.",

--- a/testdata/noterror/rs_git.rs.json
+++ b/testdata/noterror/rs_git.rs.json
@@ -12,11 +12,11 @@
             "ns2.paukhost.com"
         ],
         "created_date": "28.11.2018 22:06:38",
-        "created_date_parsed": "2018-11-28T22:06:38Z",
+        "created_date_in_time": "2018-11-28T22:06:38Z",
         "updated_date": "01.11.2019 14:23:58",
-        "updated_date_parsed": "2019-11-01T14:23:58Z",
+        "updated_date_in_time": "2019-11-01T14:23:58Z",
         "expiration_date": "28.11.2020 22:06:38",
-        "expiration_date_parsed": "2020-11-28T22:06:38Z"
+        "expiration_date_in_time": "2020-11-28T22:06:38Z"
     },
     "registrar": {
         "name": "Stanco d.o.o."

--- a/testdata/noterror/rs_git.rs.json
+++ b/testdata/noterror/rs_git.rs.json
@@ -12,8 +12,11 @@
             "ns2.paukhost.com"
         ],
         "created_date": "28.11.2018 22:06:38",
+        "created_date_parsed": "2018-11-28T22:06:38Z",
         "updated_date": "01.11.2019 14:23:58",
-        "expiration_date": "28.11.2020 22:06:38"
+        "updated_date_parsed": "2019-11-01T14:23:58Z",
+        "expiration_date": "28.11.2020 22:06:38",
+        "expiration_date_parsed": "2020-11-28T22:06:38Z"
     },
     "registrar": {
         "name": "Stanco d.o.o."

--- a/testdata/noterror/rs_google.rs.json
+++ b/testdata/noterror/rs_google.rs.json
@@ -15,11 +15,11 @@
             "ns4.google.com"
         ],
         "created_date": "10.03.2008 12:31:19",
-        "created_date_parsed": "2008-03-10T12:31:19Z",
+        "created_date_in_time": "2008-03-10T12:31:19Z",
         "updated_date": "07.02.2020 18:38:00",
-        "updated_date_parsed": "2020-02-07T18:38:00Z",
+        "updated_date_in_time": "2020-02-07T18:38:00Z",
         "expiration_date": "10.03.2021 12:31:19",
-        "expiration_date_parsed": "2021-03-10T12:31:19Z"
+        "expiration_date_in_time": "2021-03-10T12:31:19Z"
     },
     "registrar": {
         "name": "NINET Company d.o.o."

--- a/testdata/noterror/rs_google.rs.json
+++ b/testdata/noterror/rs_google.rs.json
@@ -15,8 +15,11 @@
             "ns4.google.com"
         ],
         "created_date": "10.03.2008 12:31:19",
+        "created_date_parsed": "2008-03-10T12:31:19Z",
         "updated_date": "07.02.2020 18:38:00",
-        "expiration_date": "10.03.2021 12:31:19"
+        "updated_date_parsed": "2020-02-07T18:38:00Z",
+        "expiration_date": "10.03.2021 12:31:19",
+        "expiration_date_parsed": "2021-03-10T12:31:19Z"
     },
     "registrar": {
         "name": "NINET Company d.o.o."

--- a/testdata/noterror/ru_git.ru.json
+++ b/testdata/noterror/ru_git.ru.json
@@ -14,9 +14,9 @@
             "ns2.telekom.ru"
         ],
         "created_date": "2001-11-19T21:00:00Z",
-        "created_date_parsed": "2001-11-19T21:00:00Z",
+        "created_date_in_time": "2001-11-19T21:00:00Z",
         "expiration_date": "2020-11-20T21:00:00Z",
-        "expiration_date_parsed": "2020-11-20T21:00:00Z"
+        "expiration_date_in_time": "2020-11-20T21:00:00Z"
     },
     "registrar": {
         "name": "RELCOMHOST-RU"

--- a/testdata/noterror/ru_git.ru.json
+++ b/testdata/noterror/ru_git.ru.json
@@ -14,7 +14,9 @@
             "ns2.telekom.ru"
         ],
         "created_date": "2001-11-19T21:00:00Z",
-        "expiration_date": "2020-11-20T21:00:00Z"
+        "created_date_parsed": "2001-11-19T21:00:00Z",
+        "expiration_date": "2020-11-20T21:00:00Z",
+        "expiration_date_parsed": "2020-11-20T21:00:00Z"
     },
     "registrar": {
         "name": "RELCOMHOST-RU"

--- a/testdata/noterror/ru_google.ru.json
+++ b/testdata/noterror/ru_google.ru.json
@@ -16,9 +16,9 @@
             "ns4.google.com"
         ],
         "created_date": "2004-03-03T21:00:00Z",
-        "created_date_parsed": "2004-03-03T21:00:00Z",
+        "created_date_in_time": "2004-03-03T21:00:00Z",
         "expiration_date": "2020-03-04T21:00:00Z",
-        "expiration_date_parsed": "2020-03-04T21:00:00Z"
+        "expiration_date_in_time": "2020-03-04T21:00:00Z"
     },
     "registrar": {
         "name": "RU-CENTER-RU"

--- a/testdata/noterror/ru_google.ru.json
+++ b/testdata/noterror/ru_google.ru.json
@@ -16,7 +16,9 @@
             "ns4.google.com"
         ],
         "created_date": "2004-03-03T21:00:00Z",
-        "expiration_date": "2020-03-04T21:00:00Z"
+        "created_date_parsed": "2004-03-03T21:00:00Z",
+        "expiration_date": "2020-03-04T21:00:00Z",
+        "expiration_date_parsed": "2020-03-04T21:00:00Z"
     },
     "registrar": {
         "name": "RU-CENTER-RU"

--- a/testdata/noterror/ru_yandex.ru.json
+++ b/testdata/noterror/ru_yandex.ru.json
@@ -15,7 +15,9 @@
             "ns9.z5h64q92x9.net"
         ],
         "created_date": "1997-09-23T09:45:07Z",
-        "expiration_date": "2021-09-30T21:00:00Z"
+        "created_date_parsed": "1997-09-23T09:45:07Z",
+        "expiration_date": "2021-09-30T21:00:00Z",
+        "expiration_date_parsed": "2021-09-30T21:00:00Z"
     },
     "registrar": {
         "name": "RU-CENTER-RU"

--- a/testdata/noterror/ru_yandex.ru.json
+++ b/testdata/noterror/ru_yandex.ru.json
@@ -15,9 +15,9 @@
             "ns9.z5h64q92x9.net"
         ],
         "created_date": "1997-09-23T09:45:07Z",
-        "created_date_parsed": "1997-09-23T09:45:07Z",
+        "created_date_in_time": "1997-09-23T09:45:07Z",
         "expiration_date": "2021-09-30T21:00:00Z",
-        "expiration_date_parsed": "2021-09-30T21:00:00Z"
+        "expiration_date_in_time": "2021-09-30T21:00:00Z"
     },
     "registrar": {
         "name": "RU-CENTER-RU"

--- a/testdata/noterror/scot_gov.scot.json
+++ b/testdata/noterror/scot_gov.scot.json
@@ -18,11 +18,11 @@
             "ns0.ja.net"
         ],
         "created_date": "2015-01-07T09:26:57.553Z",
-        "created_date_parsed": "2015-01-07T09:26:57.553Z",
+        "created_date_in_time": "2015-01-07T09:26:57.553Z",
         "updated_date": "2019-09-29T08:12:11.484Z",
-        "updated_date_parsed": "2019-09-29T08:12:11.484Z",
+        "updated_date_in_time": "2019-09-29T08:12:11.484Z",
         "expiration_date": "2021-01-07T09:26:57.553Z",
-        "expiration_date_parsed": "2021-01-07T09:26:57.553Z"
+        "expiration_date_in_time": "2021-01-07T09:26:57.553Z"
     },
     "registrar": {
         "id": "1488",

--- a/testdata/noterror/scot_gov.scot.json
+++ b/testdata/noterror/scot_gov.scot.json
@@ -18,8 +18,11 @@
             "ns0.ja.net"
         ],
         "created_date": "2015-01-07T09:26:57.553Z",
+        "created_date_parsed": "2015-01-07T09:26:57.553Z",
         "updated_date": "2019-09-29T08:12:11.484Z",
-        "expiration_date": "2021-01-07T09:26:57.553Z"
+        "updated_date_parsed": "2019-09-29T08:12:11.484Z",
+        "expiration_date": "2021-01-07T09:26:57.553Z",
+        "expiration_date_parsed": "2021-01-07T09:26:57.553Z"
     },
     "registrar": {
         "id": "1488",

--- a/testdata/noterror/scot_yes.scot.json
+++ b/testdata/noterror/scot_yes.scot.json
@@ -16,11 +16,11 @@
             "ns-1938.awsdns-50.co.uk"
         ],
         "created_date": "2014-07-15T12:05:57.342Z",
-        "created_date_parsed": "2014-07-15T12:05:57.342Z",
+        "created_date_in_time": "2014-07-15T12:05:57.342Z",
         "updated_date": "2019-08-29T12:08:46.864Z",
-        "updated_date_parsed": "2019-08-29T12:08:46.864Z",
+        "updated_date_in_time": "2019-08-29T12:08:46.864Z",
         "expiration_date": "2020-07-15T12:05:57.342Z",
-        "expiration_date_parsed": "2020-07-15T12:05:57.342Z"
+        "expiration_date_in_time": "2020-07-15T12:05:57.342Z"
     },
     "registrar": {
         "id": "15",

--- a/testdata/noterror/scot_yes.scot.json
+++ b/testdata/noterror/scot_yes.scot.json
@@ -16,8 +16,11 @@
             "ns-1938.awsdns-50.co.uk"
         ],
         "created_date": "2014-07-15T12:05:57.342Z",
+        "created_date_parsed": "2014-07-15T12:05:57.342Z",
         "updated_date": "2019-08-29T12:08:46.864Z",
-        "expiration_date": "2020-07-15T12:05:57.342Z"
+        "updated_date_parsed": "2019-08-29T12:08:46.864Z",
+        "expiration_date": "2020-07-15T12:05:57.342Z",
+        "expiration_date_parsed": "2020-07-15T12:05:57.342Z"
     },
     "registrar": {
         "id": "15",

--- a/testdata/noterror/sexy_line.sexy.json
+++ b/testdata/noterror/sexy_line.sexy.json
@@ -15,8 +15,11 @@
             "ns3.wordpress.com"
         ],
         "created_date": "2018-07-20T09:58:25Z",
+        "created_date_parsed": "2018-07-20T09:58:25Z",
         "updated_date": "2019-07-29T09:06:46Z",
-        "expiration_date": "2020-07-20T09:58:25Z"
+        "updated_date_parsed": "2019-07-29T09:06:46Z",
+        "expiration_date": "2020-07-20T09:58:25Z",
+        "expiration_date_parsed": "2020-07-20T09:58:25Z"
     },
     "registrar": {
         "id": "1531",

--- a/testdata/noterror/sexy_line.sexy.json
+++ b/testdata/noterror/sexy_line.sexy.json
@@ -15,11 +15,11 @@
             "ns3.wordpress.com"
         ],
         "created_date": "2018-07-20T09:58:25Z",
-        "created_date_parsed": "2018-07-20T09:58:25Z",
+        "created_date_in_time": "2018-07-20T09:58:25Z",
         "updated_date": "2019-07-29T09:06:46Z",
-        "updated_date_parsed": "2019-07-29T09:06:46Z",
+        "updated_date_in_time": "2019-07-29T09:06:46Z",
         "expiration_date": "2020-07-20T09:58:25Z",
-        "expiration_date_parsed": "2020-07-20T09:58:25Z"
+        "expiration_date_in_time": "2020-07-20T09:58:25Z"
     },
     "registrar": {
         "id": "1531",

--- a/testdata/noterror/sh_git.sh.json
+++ b/testdata/noterror/sh_git.sh.json
@@ -13,11 +13,11 @@
             "ns2.ezdnscenter.com"
         ],
         "created_date": "2009-04-13T05:16:13Z",
-        "created_date_parsed": "2009-04-13T05:16:13Z",
+        "created_date_in_time": "2009-04-13T05:16:13Z",
         "updated_date": "2019-04-13T22:28:39Z",
-        "updated_date_parsed": "2019-04-13T22:28:39Z",
+        "updated_date_in_time": "2019-04-13T22:28:39Z",
         "expiration_date": "2020-04-13T05:16:13Z",
-        "expiration_date_parsed": "2020-04-13T05:16:13Z"
+        "expiration_date_in_time": "2020-04-13T05:16:13Z"
     },
     "registrar": {
         "id": "1868",

--- a/testdata/noterror/sh_git.sh.json
+++ b/testdata/noterror/sh_git.sh.json
@@ -13,8 +13,11 @@
             "ns2.ezdnscenter.com"
         ],
         "created_date": "2009-04-13T05:16:13Z",
+        "created_date_parsed": "2009-04-13T05:16:13Z",
         "updated_date": "2019-04-13T22:28:39Z",
-        "expiration_date": "2020-04-13T05:16:13Z"
+        "updated_date_parsed": "2019-04-13T22:28:39Z",
+        "expiration_date": "2020-04-13T05:16:13Z",
+        "expiration_date_parsed": "2020-04-13T05:16:13Z"
     },
     "registrar": {
         "id": "1868",

--- a/testdata/noterror/su_git.su.json
+++ b/testdata/noterror/su_git.su.json
@@ -19,7 +19,9 @@
             "ns5.linode.com"
         ],
         "created_date": "2013-03-26T19:00:20Z",
-        "expiration_date": "2020-03-26T20:00:20Z"
+        "created_date_parsed": "2013-03-26T19:00:20Z",
+        "expiration_date": "2020-03-26T20:00:20Z",
+        "expiration_date_parsed": "2020-03-26T20:00:20Z"
     },
     "registrar": {
         "name": "DOMENUS-SU"

--- a/testdata/noterror/su_git.su.json
+++ b/testdata/noterror/su_git.su.json
@@ -19,9 +19,9 @@
             "ns5.linode.com"
         ],
         "created_date": "2013-03-26T19:00:20Z",
-        "created_date_parsed": "2013-03-26T19:00:20Z",
+        "created_date_in_time": "2013-03-26T19:00:20Z",
         "expiration_date": "2020-03-26T20:00:20Z",
-        "expiration_date_parsed": "2020-03-26T20:00:20Z"
+        "expiration_date_in_time": "2020-03-26T20:00:20Z"
     },
     "registrar": {
         "name": "DOMENUS-SU"

--- a/testdata/noterror/su_google.su.json
+++ b/testdata/noterror/su_google.su.json
@@ -14,7 +14,9 @@
             "ns8.nic.ru"
         ],
         "created_date": "2005-10-15T20:00:00Z",
-        "expiration_date": "2019-10-15T21:00:00Z"
+        "created_date_parsed": "2005-10-15T20:00:00Z",
+        "expiration_date": "2019-10-15T21:00:00Z",
+        "expiration_date_parsed": "2019-10-15T21:00:00Z"
     },
     "registrar": {
         "name": "RUCENTER-SU"

--- a/testdata/noterror/su_google.su.json
+++ b/testdata/noterror/su_google.su.json
@@ -14,9 +14,9 @@
             "ns8.nic.ru"
         ],
         "created_date": "2005-10-15T20:00:00Z",
-        "created_date_parsed": "2005-10-15T20:00:00Z",
+        "created_date_in_time": "2005-10-15T20:00:00Z",
         "expiration_date": "2019-10-15T21:00:00Z",
-        "expiration_date_parsed": "2019-10-15T21:00:00Z"
+        "expiration_date_in_time": "2019-10-15T21:00:00Z"
     },
     "registrar": {
         "name": "RUCENTER-SU"

--- a/testdata/noterror/tel_github.tel.json
+++ b/testdata/noterror/tel_github.tel.json
@@ -20,8 +20,11 @@
             "ns6.markmonitor.com"
         ],
         "created_date": "2012-05-29T19:21:21Z",
+        "created_date_parsed": "2012-05-29T19:21:21Z",
         "updated_date": "2018-05-01T09:13:33Z",
-        "expiration_date": "2020-05-28T23:59:59Z"
+        "updated_date_parsed": "2018-05-01T09:13:33Z",
+        "expiration_date": "2020-05-28T23:59:59Z",
+        "expiration_date_parsed": "2020-05-28T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/tel_github.tel.json
+++ b/testdata/noterror/tel_github.tel.json
@@ -20,11 +20,11 @@
             "ns6.markmonitor.com"
         ],
         "created_date": "2012-05-29T19:21:21Z",
-        "created_date_parsed": "2012-05-29T19:21:21Z",
+        "created_date_in_time": "2012-05-29T19:21:21Z",
         "updated_date": "2018-05-01T09:13:33Z",
-        "updated_date_parsed": "2018-05-01T09:13:33Z",
+        "updated_date_in_time": "2018-05-01T09:13:33Z",
         "expiration_date": "2020-05-28T23:59:59Z",
-        "expiration_date_parsed": "2020-05-28T23:59:59Z"
+        "expiration_date_in_time": "2020-05-28T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/tel_google.tel.json
+++ b/testdata/noterror/tel_google.tel.json
@@ -17,11 +17,11 @@
             "ns3.google.com"
         ],
         "created_date": "2009-01-22T21:06:56Z",
-        "created_date_parsed": "2009-01-22T21:06:56Z",
+        "created_date_in_time": "2009-01-22T21:06:56Z",
         "updated_date": "2019-02-23T10:48:27Z",
-        "updated_date_parsed": "2019-02-23T10:48:27Z",
+        "updated_date_in_time": "2019-02-23T10:48:27Z",
         "expiration_date": "2020-03-22T23:59:59Z",
-        "expiration_date_parsed": "2020-03-22T23:59:59Z"
+        "expiration_date_in_time": "2020-03-22T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/tel_google.tel.json
+++ b/testdata/noterror/tel_google.tel.json
@@ -17,8 +17,11 @@
             "ns3.google.com"
         ],
         "created_date": "2009-01-22T21:06:56Z",
+        "created_date_parsed": "2009-01-22T21:06:56Z",
         "updated_date": "2019-02-23T10:48:27Z",
-        "expiration_date": "2020-03-22T23:59:59Z"
+        "updated_date_parsed": "2019-02-23T10:48:27Z",
+        "expiration_date": "2020-03-22T23:59:59Z",
+        "expiration_date_parsed": "2020-03-22T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/tf_git.tf.json
+++ b/testdata/noterror/tf_git.tf.json
@@ -12,11 +12,11 @@
             "ns2.parkingcrew.net"
         ],
         "created_date": "2019-01-20T04:16:05Z",
-        "created_date_parsed": "2019-01-20T04:16:05Z",
+        "created_date_in_time": "2019-01-20T04:16:05Z",
         "updated_date": "2019-01-21T15:35:50Z",
-        "updated_date_parsed": "2019-01-21T15:35:50Z",
+        "updated_date_in_time": "2019-01-21T15:35:50Z",
         "expiration_date": "2020-01-20T04:16:05Z",
-        "expiration_date_parsed": "2020-01-20T04:16:05Z"
+        "expiration_date_in_time": "2020-01-20T04:16:05Z"
     },
     "registrar": {
         "name": "1API GmbH",

--- a/testdata/noterror/tf_git.tf.json
+++ b/testdata/noterror/tf_git.tf.json
@@ -12,8 +12,11 @@
             "ns2.parkingcrew.net"
         ],
         "created_date": "2019-01-20T04:16:05Z",
+        "created_date_parsed": "2019-01-20T04:16:05Z",
         "updated_date": "2019-01-21T15:35:50Z",
-        "expiration_date": "2020-01-20T04:16:05Z"
+        "updated_date_parsed": "2019-01-21T15:35:50Z",
+        "expiration_date": "2020-01-20T04:16:05Z",
+        "expiration_date_parsed": "2020-01-20T04:16:05Z"
     },
     "registrar": {
         "name": "1API GmbH",

--- a/testdata/noterror/tf_google.tf.json
+++ b/testdata/noterror/tf_google.tf.json
@@ -12,8 +12,11 @@
             "ns3.markmonitor.com"
         ],
         "created_date": "2011-12-06T09:12:58Z",
+        "created_date_parsed": "2011-12-06T09:12:58Z",
         "updated_date": "2019-01-14T10:32:14Z",
-        "expiration_date": "2020-02-15T19:06:41Z"
+        "updated_date_parsed": "2019-01-14T10:32:14Z",
+        "expiration_date": "2020-02-15T19:06:41Z",
+        "expiration_date_parsed": "2020-02-15T19:06:41Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/tf_google.tf.json
+++ b/testdata/noterror/tf_google.tf.json
@@ -12,11 +12,11 @@
             "ns3.markmonitor.com"
         ],
         "created_date": "2011-12-06T09:12:58Z",
-        "created_date_parsed": "2011-12-06T09:12:58Z",
+        "created_date_in_time": "2011-12-06T09:12:58Z",
         "updated_date": "2019-01-14T10:32:14Z",
-        "updated_date_parsed": "2019-01-14T10:32:14Z",
+        "updated_date_in_time": "2019-01-14T10:32:14Z",
         "expiration_date": "2020-02-15T19:06:41Z",
-        "expiration_date_parsed": "2020-02-15T19:06:41Z"
+        "expiration_date_in_time": "2020-02-15T19:06:41Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/tk_google.tk.json
+++ b/testdata/noterror/tk_google.tk.json
@@ -14,7 +14,9 @@
             "ns4.google.com"
         ],
         "created_date": "12/18/2001",
-        "expiration_date": "03/02/2020"
+        "created_date_parsed": "2001-12-18T00:00:00Z",
+        "expiration_date": "03/02/2020",
+        "expiration_date_parsed": "2020-02-03T00:00:00Z"
     },
     "registrant": {
         "name": "Domain Administrator",

--- a/testdata/noterror/tk_google.tk.json
+++ b/testdata/noterror/tk_google.tk.json
@@ -14,9 +14,9 @@
             "ns4.google.com"
         ],
         "created_date": "12/18/2001",
-        "created_date_parsed": "2001-12-18T00:00:00Z",
+        "created_date_in_time": "2001-12-18T00:00:00Z",
         "expiration_date": "03/02/2020",
-        "expiration_date_parsed": "2020-02-03T00:00:00Z"
+        "expiration_date_in_time": "2020-02-03T00:00:00Z"
     },
     "registrant": {
         "name": "Domain Administrator",

--- a/testdata/noterror/tk_zcore.tk.json
+++ b/testdata/noterror/tk_zcore.tk.json
@@ -11,7 +11,9 @@
             "ns04.freenom.com"
         ],
         "created_date": "11/29/2016",
-        "expiration_date": "01/03/2022"
+        "created_date_parsed": "2016-11-29T00:00:00Z",
+        "expiration_date": "01/03/2022",
+        "expiration_date_parsed": "2022-03-01T00:00:00Z"
     },
     "registrant": {
         "name": "Korol",

--- a/testdata/noterror/tk_zcore.tk.json
+++ b/testdata/noterror/tk_zcore.tk.json
@@ -11,9 +11,9 @@
             "ns04.freenom.com"
         ],
         "created_date": "11/29/2016",
-        "created_date_parsed": "2016-11-29T00:00:00Z",
+        "created_date_in_time": "2016-11-29T00:00:00Z",
         "expiration_date": "01/03/2022",
-        "expiration_date_parsed": "2022-03-01T00:00:00Z"
+        "expiration_date_in_time": "2022-03-01T00:00:00Z"
     },
     "registrant": {
         "name": "Korol",

--- a/testdata/noterror/top_otto.top.json
+++ b/testdata/noterror/top_otto.top.json
@@ -16,8 +16,11 @@
             "ns4.p20.dynect.net"
         ],
         "created_date": "2015-02-26T13:19:20Z",
+        "created_date_parsed": "2015-02-26T13:19:20Z",
         "updated_date": "2019-03-05T07:41:41Z",
-        "expiration_date": "2020-02-26T13:19:20Z"
+        "updated_date_parsed": "2019-03-05T07:41:41Z",
+        "expiration_date": "2020-02-26T13:19:20Z",
+        "expiration_date_parsed": "2020-02-26T13:19:20Z"
     },
     "registrar": {
         "id": "269",

--- a/testdata/noterror/top_otto.top.json
+++ b/testdata/noterror/top_otto.top.json
@@ -16,11 +16,11 @@
             "ns4.p20.dynect.net"
         ],
         "created_date": "2015-02-26T13:19:20Z",
-        "created_date_parsed": "2015-02-26T13:19:20Z",
+        "created_date_in_time": "2015-02-26T13:19:20Z",
         "updated_date": "2019-03-05T07:41:41Z",
-        "updated_date_parsed": "2019-03-05T07:41:41Z",
+        "updated_date_in_time": "2019-03-05T07:41:41Z",
         "expiration_date": "2020-02-26T13:19:20Z",
-        "expiration_date_parsed": "2020-02-26T13:19:20Z"
+        "expiration_date_in_time": "2020-02-26T13:19:20Z"
     },
     "registrar": {
         "id": "269",

--- a/testdata/noterror/travel_google.travel.json
+++ b/testdata/noterror/travel_google.travel.json
@@ -17,8 +17,11 @@
             "ns4.google.com"
         ],
         "created_date": "2005-10-03T14:16:24Z",
+        "created_date_parsed": "2005-10-03T14:16:24Z",
         "updated_date": "2019-09-04T12:23:16Z",
-        "expiration_date": "2020-10-02T23:59:59Z"
+        "updated_date_parsed": "2019-09-04T12:23:16Z",
+        "expiration_date": "2020-10-02T23:59:59Z",
+        "expiration_date_parsed": "2020-10-02T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/travel_google.travel.json
+++ b/testdata/noterror/travel_google.travel.json
@@ -17,11 +17,11 @@
             "ns4.google.com"
         ],
         "created_date": "2005-10-03T14:16:24Z",
-        "created_date_parsed": "2005-10-03T14:16:24Z",
+        "created_date_in_time": "2005-10-03T14:16:24Z",
         "updated_date": "2019-09-04T12:23:16Z",
-        "updated_date_parsed": "2019-09-04T12:23:16Z",
+        "updated_date_in_time": "2019-09-04T12:23:16Z",
         "expiration_date": "2020-10-02T23:59:59Z",
-        "expiration_date_parsed": "2020-10-02T23:59:59Z"
+        "expiration_date_in_time": "2020-10-02T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/travel_xplor.travel.json
+++ b/testdata/noterror/travel_xplor.travel.json
@@ -15,8 +15,11 @@
             "ns-1661.awsdns-15.co.uk"
         ],
         "created_date": "2008-06-04T05:15:38Z",
+        "created_date_parsed": "2008-06-04T05:15:38Z",
         "updated_date": "2019-10-01T22:38:39Z",
-        "expiration_date": "2020-06-03T23:59:59Z"
+        "updated_date_parsed": "2019-10-01T22:38:39Z",
+        "expiration_date": "2020-06-03T23:59:59Z",
+        "expiration_date_parsed": "2020-06-03T23:59:59Z"
     },
     "registrar": {
         "id": "455",

--- a/testdata/noterror/travel_xplor.travel.json
+++ b/testdata/noterror/travel_xplor.travel.json
@@ -15,11 +15,11 @@
             "ns-1661.awsdns-15.co.uk"
         ],
         "created_date": "2008-06-04T05:15:38Z",
-        "created_date_parsed": "2008-06-04T05:15:38Z",
+        "created_date_in_time": "2008-06-04T05:15:38Z",
         "updated_date": "2019-10-01T22:38:39Z",
-        "updated_date_parsed": "2019-10-01T22:38:39Z",
+        "updated_date_in_time": "2019-10-01T22:38:39Z",
         "expiration_date": "2020-06-03T23:59:59Z",
-        "expiration_date_parsed": "2020-06-03T23:59:59Z"
+        "expiration_date_in_time": "2020-06-03T23:59:59Z"
     },
     "registrar": {
         "id": "455",

--- a/testdata/noterror/tw_google.com.tw.json
+++ b/testdata/noterror/tw_google.com.tw.json
@@ -16,7 +16,9 @@
             "ns4.google.com"
         ],
         "created_date": "2000-08-29 10:22:50 (UTC+8)",
-        "expiration_date": "2021-11-09 00:00:00 (UTC+8)"
+        "created_date_parsed": "2000-08-29T08:22:50Z",
+        "expiration_date": "2021-11-09 00:00:00 (UTC+8)",
+        "expiration_date_parsed": "2021-11-09T08:00:00Z"
     },
     "registrar": {
         "name": "Markmonitor, Inc.",

--- a/testdata/noterror/tw_google.com.tw.json
+++ b/testdata/noterror/tw_google.com.tw.json
@@ -16,9 +16,9 @@
             "ns4.google.com"
         ],
         "created_date": "2000-08-29 10:22:50 (UTC+8)",
-        "created_date_parsed": "2000-08-29T08:22:50Z",
+        "created_date_in_time": "2000-08-29T08:22:50Z",
         "expiration_date": "2021-11-09 00:00:00 (UTC+8)",
-        "expiration_date_parsed": "2021-11-09T08:00:00Z"
+        "expiration_date_in_time": "2021-11-09T08:00:00Z"
     },
     "registrar": {
         "name": "Markmonitor, Inc.",

--- a/testdata/noterror/tw_google.net.tw.json
+++ b/testdata/noterror/tw_google.net.tw.json
@@ -12,9 +12,9 @@
             "ns2.afraid.org"
         ],
         "created_date": "2010-08-13 23:16:40 (UTC+8)",
-        "created_date_parsed": "2010-08-13T08:16:40Z",
+        "created_date_in_time": "2010-08-13T08:16:40Z",
         "expiration_date": "2021-08-13 00:00:00 (UTC+8)",
-        "expiration_date_parsed": "2021-08-13T08:00:00Z"
+        "expiration_date_in_time": "2021-08-13T08:00:00Z"
     },
     "registrar": {
         "name": "NET-CHINESE",

--- a/testdata/noterror/tw_google.net.tw.json
+++ b/testdata/noterror/tw_google.net.tw.json
@@ -12,7 +12,9 @@
             "ns2.afraid.org"
         ],
         "created_date": "2010-08-13 23:16:40 (UTC+8)",
-        "expiration_date": "2021-08-13 00:00:00 (UTC+8)"
+        "created_date_parsed": "2010-08-13T08:16:40Z",
+        "expiration_date": "2021-08-13 00:00:00 (UTC+8)",
+        "expiration_date_parsed": "2021-08-13T08:00:00Z"
     },
     "registrar": {
         "name": "NET-CHINESE",

--- a/testdata/noterror/tw_google.org.tw.json
+++ b/testdata/noterror/tw_google.org.tw.json
@@ -12,9 +12,9 @@
             "ns50.cx901.com"
         ],
         "created_date": "2017-01-14 19:27:47 (UTC+8)",
-        "created_date_parsed": "2017-01-14T08:27:47Z",
+        "created_date_in_time": "2017-01-14T08:27:47Z",
         "expiration_date": "2022-01-14 00:00:00 (UTC+8)",
-        "expiration_date_parsed": "2022-01-14T08:00:00Z"
+        "expiration_date_in_time": "2022-01-14T08:00:00Z"
     },
     "registrar": {
         "name": "HINET",

--- a/testdata/noterror/tw_google.org.tw.json
+++ b/testdata/noterror/tw_google.org.tw.json
@@ -12,7 +12,9 @@
             "ns50.cx901.com"
         ],
         "created_date": "2017-01-14 19:27:47 (UTC+8)",
-        "expiration_date": "2022-01-14 00:00:00 (UTC+8)"
+        "created_date_parsed": "2017-01-14T08:27:47Z",
+        "expiration_date": "2022-01-14 00:00:00 (UTC+8)",
+        "expiration_date_parsed": "2022-01-14T08:00:00Z"
     },
     "registrar": {
         "name": "HINET",

--- a/testdata/noterror/tw_specialized.com.tw.json
+++ b/testdata/noterror/tw_specialized.com.tw.json
@@ -12,9 +12,9 @@
             "cns2.net-chinese.com.tw"
         ],
         "created_date": "2015-12-09 12:30:05 (UTC+8)",
-        "created_date_parsed": "2015-12-09T08:30:05Z",
+        "created_date_in_time": "2015-12-09T08:30:05Z",
         "expiration_date": "2021-12-09 12:30:05 (UTC+8)",
-        "expiration_date_parsed": "2021-12-09T08:30:05Z"
+        "expiration_date_in_time": "2021-12-09T08:30:05Z"
     },
     "registrar": {
         "name": "NET-CHINESE",

--- a/testdata/noterror/tw_specialized.com.tw.json
+++ b/testdata/noterror/tw_specialized.com.tw.json
@@ -12,7 +12,9 @@
             "cns2.net-chinese.com.tw"
         ],
         "created_date": "2015-12-09 12:30:05 (UTC+8)",
-        "expiration_date": "2021-12-09 12:30:05 (UTC+8)"
+        "created_date_parsed": "2015-12-09T08:30:05Z",
+        "expiration_date": "2021-12-09 12:30:05 (UTC+8)",
+        "expiration_date_parsed": "2021-12-09T08:30:05Z"
     },
     "registrar": {
         "name": "NET-CHINESE",

--- a/testdata/noterror/uk_git.uk.json
+++ b/testdata/noterror/uk_git.uk.json
@@ -12,11 +12,11 @@
             "ns2.123-reg.co.uk"
         ],
         "created_date": "22-Oct-2017",
-        "created_date_parsed": "2017-10-22T00:00:00Z",
+        "created_date_in_time": "2017-10-22T00:00:00Z",
         "updated_date": "29-Jun-2019",
-        "updated_date_parsed": "2019-06-29T00:00:00Z",
+        "updated_date_in_time": "2019-06-29T00:00:00Z",
         "expiration_date": "22-Oct-2019",
-        "expiration_date_parsed": "2019-10-22T00:00:00Z"
+        "expiration_date_in_time": "2019-10-22T00:00:00Z"
     },
     "registrar": {
         "name": "123-Reg Limited t/a 123-reg [Tag = 123-REG]",

--- a/testdata/noterror/uk_git.uk.json
+++ b/testdata/noterror/uk_git.uk.json
@@ -12,8 +12,11 @@
             "ns2.123-reg.co.uk"
         ],
         "created_date": "22-Oct-2017",
+        "created_date_parsed": "2017-10-22T00:00:00Z",
         "updated_date": "29-Jun-2019",
-        "expiration_date": "22-Oct-2019"
+        "updated_date_parsed": "2019-06-29T00:00:00Z",
+        "expiration_date": "22-Oct-2019",
+        "expiration_date_parsed": "2019-10-22T00:00:00Z"
     },
     "registrar": {
         "name": "123-Reg Limited t/a 123-reg [Tag = 123-REG]",

--- a/testdata/noterror/uk_google.uk.json
+++ b/testdata/noterror/uk_google.uk.json
@@ -14,8 +14,11 @@
             "ns4.googledomains.com"
         ],
         "created_date": "11-Jun-2014",
+        "created_date_parsed": "2014-06-11T00:00:00Z",
         "updated_date": "10-May-2019",
-        "expiration_date": "11-Jun-2020"
+        "updated_date_parsed": "2019-05-10T00:00:00Z",
+        "expiration_date": "11-Jun-2020",
+        "expiration_date_parsed": "2020-06-11T00:00:00Z"
     },
     "registrar": {
         "name": "Markmonitor Inc. t/a MarkMonitor Inc. [Tag = MARKMONITOR]",

--- a/testdata/noterror/uk_google.uk.json
+++ b/testdata/noterror/uk_google.uk.json
@@ -14,11 +14,11 @@
             "ns4.googledomains.com"
         ],
         "created_date": "11-Jun-2014",
-        "created_date_parsed": "2014-06-11T00:00:00Z",
+        "created_date_in_time": "2014-06-11T00:00:00Z",
         "updated_date": "10-May-2019",
-        "updated_date_parsed": "2019-05-10T00:00:00Z",
+        "updated_date_in_time": "2019-05-10T00:00:00Z",
         "expiration_date": "11-Jun-2020",
-        "expiration_date_parsed": "2020-06-11T00:00:00Z"
+        "expiration_date_in_time": "2020-06-11T00:00:00Z"
     },
     "registrar": {
         "name": "Markmonitor Inc. t/a MarkMonitor Inc. [Tag = MARKMONITOR]",

--- a/testdata/noterror/us_git.us.json
+++ b/testdata/noterror/us_git.us.json
@@ -17,8 +17,11 @@
             "ns2.namefind.com"
         ],
         "created_date": "2002-04-24T15:27:59Z",
+        "created_date_parsed": "2002-04-24T15:27:59Z",
         "updated_date": "2019-04-03T10:09:33Z",
-        "expiration_date": "2020-04-23T23:59:59Z"
+        "updated_date_parsed": "2019-04-03T10:09:33Z",
+        "expiration_date": "2020-04-23T23:59:59Z",
+        "expiration_date_parsed": "2020-04-23T23:59:59Z"
     },
     "registrar": {
         "id": "146",

--- a/testdata/noterror/us_git.us.json
+++ b/testdata/noterror/us_git.us.json
@@ -17,11 +17,11 @@
             "ns2.namefind.com"
         ],
         "created_date": "2002-04-24T15:27:59Z",
-        "created_date_parsed": "2002-04-24T15:27:59Z",
+        "created_date_in_time": "2002-04-24T15:27:59Z",
         "updated_date": "2019-04-03T10:09:33Z",
-        "updated_date_parsed": "2019-04-03T10:09:33Z",
+        "updated_date_in_time": "2019-04-03T10:09:33Z",
         "expiration_date": "2020-04-23T23:59:59Z",
-        "expiration_date_parsed": "2020-04-23T23:59:59Z"
+        "expiration_date_in_time": "2020-04-23T23:59:59Z"
     },
     "registrar": {
         "id": "146",

--- a/testdata/noterror/us_google.us.json
+++ b/testdata/noterror/us_google.us.json
@@ -17,8 +17,11 @@
             "ns1.google.com"
         ],
         "created_date": "2002-04-19T23:16:01Z",
+        "created_date_parsed": "2002-04-19T23:16:01Z",
         "updated_date": "2019-03-22T09:56:02Z",
-        "expiration_date": "2020-04-18T23:59:59Z"
+        "updated_date_parsed": "2019-03-22T09:56:02Z",
+        "expiration_date": "2020-04-18T23:59:59Z",
+        "expiration_date_parsed": "2020-04-18T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/us_google.us.json
+++ b/testdata/noterror/us_google.us.json
@@ -17,11 +17,11 @@
             "ns1.google.com"
         ],
         "created_date": "2002-04-19T23:16:01Z",
-        "created_date_parsed": "2002-04-19T23:16:01Z",
+        "created_date_in_time": "2002-04-19T23:16:01Z",
         "updated_date": "2019-03-22T09:56:02Z",
-        "updated_date_parsed": "2019-03-22T09:56:02Z",
+        "updated_date_in_time": "2019-03-22T09:56:02Z",
         "expiration_date": "2020-04-18T23:59:59Z",
-        "expiration_date_parsed": "2020-04-18T23:59:59Z"
+        "expiration_date_in_time": "2020-04-18T23:59:59Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/wales_google.wales.json
+++ b/testdata/noterror/wales_google.wales.json
@@ -17,11 +17,11 @@
             "ns3.google.com"
         ],
         "created_date": "2014-10-31T13:27:43Z",
-        "created_date_parsed": "2014-10-31T13:27:43Z",
+        "created_date_in_time": "2014-10-31T13:27:43Z",
         "updated_date": "2019-09-29T09:41:08Z",
-        "updated_date_parsed": "2019-09-29T09:41:08Z",
+        "updated_date_in_time": "2019-09-29T09:41:08Z",
         "expiration_date": "2020-10-31T13:27:43Z",
-        "expiration_date_parsed": "2020-10-31T13:27:43Z"
+        "expiration_date_in_time": "2020-10-31T13:27:43Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/wales_google.wales.json
+++ b/testdata/noterror/wales_google.wales.json
@@ -17,8 +17,11 @@
             "ns3.google.com"
         ],
         "created_date": "2014-10-31T13:27:43Z",
+        "created_date_parsed": "2014-10-31T13:27:43Z",
         "updated_date": "2019-09-29T09:41:08Z",
-        "expiration_date": "2020-10-31T13:27:43Z"
+        "updated_date_parsed": "2019-09-29T09:41:08Z",
+        "expiration_date": "2020-10-31T13:27:43Z",
+        "expiration_date_parsed": "2020-10-31T13:27:43Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/wales_gov.wales.json
+++ b/testdata/noterror/wales_gov.wales.json
@@ -15,11 +15,11 @@
             "ns2.ja.net"
         ],
         "created_date": "2015-01-14T13:49:09Z",
-        "created_date_parsed": "2015-01-14T13:49:09Z",
+        "created_date_in_time": "2015-01-14T13:49:09Z",
         "updated_date": "2019-10-01T10:07:25Z",
-        "updated_date_parsed": "2019-10-01T10:07:25Z",
+        "updated_date_in_time": "2019-10-01T10:07:25Z",
         "expiration_date": "2020-01-14T13:49:09Z",
-        "expiration_date_parsed": "2020-01-14T13:49:09Z"
+        "expiration_date_in_time": "2020-01-14T13:49:09Z"
     },
     "registrar": {
         "id": "1345",

--- a/testdata/noterror/wales_gov.wales.json
+++ b/testdata/noterror/wales_gov.wales.json
@@ -15,8 +15,11 @@
             "ns2.ja.net"
         ],
         "created_date": "2015-01-14T13:49:09Z",
+        "created_date_parsed": "2015-01-14T13:49:09Z",
         "updated_date": "2019-10-01T10:07:25Z",
-        "expiration_date": "2020-01-14T13:49:09Z"
+        "updated_date_parsed": "2019-10-01T10:07:25Z",
+        "expiration_date": "2020-01-14T13:49:09Z",
+        "expiration_date_parsed": "2020-01-14T13:49:09Z"
     },
     "registrar": {
         "id": "1345",

--- a/testdata/noterror/wf_git.wf.json
+++ b/testdata/noterror/wf_git.wf.json
@@ -16,8 +16,11 @@
         ],
         "dnssec": true,
         "created_date": "2016-04-19T17:08:51Z",
+        "created_date_parsed": "2016-04-19T17:08:51Z",
         "updated_date": "2019-05-12T21:49:18Z",
-        "expiration_date": "2019-10-19T22:07:38Z"
+        "updated_date_parsed": "2019-05-12T21:49:18Z",
+        "expiration_date": "2019-10-19T22:07:38Z",
+        "expiration_date_parsed": "2019-10-19T22:07:38Z"
     },
     "registrar": {
         "name": "INWX GmbH & Co. KG",

--- a/testdata/noterror/wf_git.wf.json
+++ b/testdata/noterror/wf_git.wf.json
@@ -16,11 +16,11 @@
         ],
         "dnssec": true,
         "created_date": "2016-04-19T17:08:51Z",
-        "created_date_parsed": "2016-04-19T17:08:51Z",
+        "created_date_in_time": "2016-04-19T17:08:51Z",
         "updated_date": "2019-05-12T21:49:18Z",
-        "updated_date_parsed": "2019-05-12T21:49:18Z",
+        "updated_date_in_time": "2019-05-12T21:49:18Z",
         "expiration_date": "2019-10-19T22:07:38Z",
-        "expiration_date_parsed": "2019-10-19T22:07:38Z"
+        "expiration_date_in_time": "2019-10-19T22:07:38Z"
     },
     "registrar": {
         "name": "INWX GmbH & Co. KG",

--- a/testdata/noterror/wf_google.wf.json
+++ b/testdata/noterror/wf_google.wf.json
@@ -12,8 +12,11 @@
             "ns3.markmonitor.com"
         ],
         "created_date": "2011-12-06T09:03:53Z",
+        "created_date_parsed": "2011-12-06T09:03:53Z",
         "updated_date": "2019-01-14T10:32:21Z",
-        "expiration_date": "2020-02-15T19:06:49Z"
+        "updated_date_parsed": "2019-01-14T10:32:21Z",
+        "expiration_date": "2020-02-15T19:06:49Z",
+        "expiration_date_parsed": "2020-02-15T19:06:49Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/wf_google.wf.json
+++ b/testdata/noterror/wf_google.wf.json
@@ -12,11 +12,11 @@
             "ns3.markmonitor.com"
         ],
         "created_date": "2011-12-06T09:03:53Z",
-        "created_date_parsed": "2011-12-06T09:03:53Z",
+        "created_date_in_time": "2011-12-06T09:03:53Z",
         "updated_date": "2019-01-14T10:32:21Z",
-        "updated_date_parsed": "2019-01-14T10:32:21Z",
+        "updated_date_in_time": "2019-01-14T10:32:21Z",
         "expiration_date": "2020-02-15T19:06:49Z",
-        "expiration_date_parsed": "2020-02-15T19:06:49Z"
+        "expiration_date_in_time": "2020-02-15T19:06:49Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/ws_github.ws.json
+++ b/testdata/noterror/ws_github.ws.json
@@ -18,8 +18,11 @@
             "ns4.p16.dynect.net"
         ],
         "created_date": "2010-08-05T17:04:22Z",
+        "created_date_parsed": "2010-08-05T17:04:22Z",
         "updated_date": "2018-07-04T09:14:12Z",
-        "expiration_date": "2020-08-05T17:04:22Z"
+        "updated_date_parsed": "2018-07-04T09:14:12Z",
+        "expiration_date": "2020-08-05T17:04:22Z",
+        "expiration_date_parsed": "2020-08-05T17:04:22Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/ws_github.ws.json
+++ b/testdata/noterror/ws_github.ws.json
@@ -18,11 +18,11 @@
             "ns4.p16.dynect.net"
         ],
         "created_date": "2010-08-05T17:04:22Z",
-        "created_date_parsed": "2010-08-05T17:04:22Z",
+        "created_date_in_time": "2010-08-05T17:04:22Z",
         "updated_date": "2018-07-04T09:14:12Z",
-        "updated_date_parsed": "2018-07-04T09:14:12Z",
+        "updated_date_in_time": "2018-07-04T09:14:12Z",
         "expiration_date": "2020-08-05T17:04:22Z",
-        "expiration_date_parsed": "2020-08-05T17:04:22Z"
+        "expiration_date_in_time": "2020-08-05T17:04:22Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/ws_google.ws.json
+++ b/testdata/noterror/ws_google.ws.json
@@ -18,11 +18,11 @@
             "ns4.google.com"
         ],
         "created_date": "2002-03-03T17:00:26Z",
-        "created_date_parsed": "2002-03-03T17:00:26Z",
+        "created_date_in_time": "2002-03-03T17:00:26Z",
         "updated_date": "2019-01-30T09:53:55Z",
-        "updated_date_parsed": "2019-01-30T09:53:55Z",
+        "updated_date_in_time": "2019-01-30T09:53:55Z",
         "expiration_date": "2020-03-03T23:00:26Z",
-        "expiration_date_parsed": "2020-03-03T23:00:26Z"
+        "expiration_date_in_time": "2020-03-03T23:00:26Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/ws_google.ws.json
+++ b/testdata/noterror/ws_google.ws.json
@@ -18,8 +18,11 @@
             "ns4.google.com"
         ],
         "created_date": "2002-03-03T17:00:26Z",
+        "created_date_parsed": "2002-03-03T17:00:26Z",
         "updated_date": "2019-01-30T09:53:55Z",
-        "expiration_date": "2020-03-03T23:00:26Z"
+        "updated_date_parsed": "2019-01-30T09:53:55Z",
+        "expiration_date": "2020-03-03T23:00:26Z",
+        "expiration_date_parsed": "2020-03-03T23:00:26Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/xn--fiqs8s_xn--6qq79v.xn--fiqs8s.json
+++ b/testdata/noterror/xn--fiqs8s_xn--6qq79v.xn--fiqs8s.json
@@ -14,9 +14,9 @@
             "ns4.dns.com"
         ],
         "created_date": "2004-08-08 22:27:10",
-        "created_date_parsed": "2004-08-08T22:27:10Z",
+        "created_date_in_time": "2004-08-08T22:27:10Z",
         "expiration_date": "2021-08-08 22:27:10",
-        "expiration_date_parsed": "2021-08-08T22:27:10Z"
+        "expiration_date_in_time": "2021-08-08T22:27:10Z"
     },
     "registrar": {
         "name": "厦门易名科技股份有限公司"

--- a/testdata/noterror/xn--fiqs8s_xn--6qq79v.xn--fiqs8s.json
+++ b/testdata/noterror/xn--fiqs8s_xn--6qq79v.xn--fiqs8s.json
@@ -14,7 +14,9 @@
             "ns4.dns.com"
         ],
         "created_date": "2004-08-08 22:27:10",
-        "expiration_date": "2021-08-08 22:27:10"
+        "created_date_parsed": "2004-08-08T22:27:10Z",
+        "expiration_date": "2021-08-08 22:27:10",
+        "expiration_date_parsed": "2021-08-08T22:27:10Z"
     },
     "registrar": {
         "name": "厦门易名科技股份有限公司"

--- a/testdata/noterror/xn--fiqs8s_xn--vhq524a.xn--fiqs8s.json
+++ b/testdata/noterror/xn--fiqs8s_xn--vhq524a.xn--fiqs8s.json
@@ -13,9 +13,9 @@
             "ns2.22.cn"
         ],
         "created_date": "2020-08-05 07:36:09",
-        "created_date_parsed": "2020-08-05T07:36:09Z",
+        "created_date_in_time": "2020-08-05T07:36:09Z",
         "expiration_date": "2021-08-05 07:36:09",
-        "expiration_date_parsed": "2021-08-05T07:36:09Z"
+        "expiration_date_in_time": "2021-08-05T07:36:09Z"
     },
     "registrar": {
         "name": "浙江贰贰网络有限公司"

--- a/testdata/noterror/xn--fiqs8s_xn--vhq524a.xn--fiqs8s.json
+++ b/testdata/noterror/xn--fiqs8s_xn--vhq524a.xn--fiqs8s.json
@@ -13,7 +13,9 @@
             "ns2.22.cn"
         ],
         "created_date": "2020-08-05 07:36:09",
-        "expiration_date": "2021-08-05 07:36:09"
+        "created_date_parsed": "2020-08-05T07:36:09Z",
+        "expiration_date": "2021-08-05 07:36:09",
+        "expiration_date_parsed": "2021-08-05T07:36:09Z"
     },
     "registrar": {
         "name": "浙江贰贰网络有限公司"

--- a/testdata/noterror/xn--mgba3a4f16a_xn--mgbu7dsvrfc.xn--mgba3a4f16a.json
+++ b/testdata/noterror/xn--mgba3a4f16a_xn--mgbu7dsvrfc.xn--mgba3a4f16a.json
@@ -8,7 +8,9 @@
             "b.nic.ir"
         ],
         "updated_date": "2020-06-24",
-        "expiration_date": "2024-10-06"
+        "updated_date_parsed": "2020-06-24T00:00:00Z",
+        "expiration_date": "2024-10-06",
+        "expiration_date_parsed": "2024-10-06T00:00:00Z"
     },
     "registrant": {
         "id": "ir00-irnic",

--- a/testdata/noterror/xn--mgba3a4f16a_xn--mgbu7dsvrfc.xn--mgba3a4f16a.json
+++ b/testdata/noterror/xn--mgba3a4f16a_xn--mgbu7dsvrfc.xn--mgba3a4f16a.json
@@ -8,9 +8,9 @@
             "b.nic.ir"
         ],
         "updated_date": "2020-06-24",
-        "updated_date_parsed": "2020-06-24T00:00:00Z",
+        "updated_date_in_time": "2020-06-24T00:00:00Z",
         "expiration_date": "2024-10-06",
-        "expiration_date_parsed": "2024-10-06T00:00:00Z"
+        "expiration_date_in_time": "2024-10-06T00:00:00Z"
     },
     "registrant": {
         "id": "ir00-irnic",

--- a/testdata/noterror/xn--mgba3a4f16a_xn--ngbmj.xn--mgba3a4f16a.json
+++ b/testdata/noterror/xn--mgba3a4f16a_xn--ngbmj.xn--mgba3a4f16a.json
@@ -9,7 +9,9 @@
             "ns2.telematics.ir"
         ],
         "updated_date": "2018-04-29",
-        "expiration_date": "2023-05-11"
+        "updated_date_parsed": "2018-04-29T00:00:00Z",
+        "expiration_date": "2023-05-11",
+        "expiration_date_parsed": "2023-05-11T00:00:00Z"
     },
     "registrant": {
         "id": "ya88-irnic",

--- a/testdata/noterror/xn--mgba3a4f16a_xn--ngbmj.xn--mgba3a4f16a.json
+++ b/testdata/noterror/xn--mgba3a4f16a_xn--ngbmj.xn--mgba3a4f16a.json
@@ -9,9 +9,9 @@
             "ns2.telematics.ir"
         ],
         "updated_date": "2018-04-29",
-        "updated_date_parsed": "2018-04-29T00:00:00Z",
+        "updated_date_in_time": "2018-04-29T00:00:00Z",
         "expiration_date": "2023-05-11",
-        "expiration_date_parsed": "2023-05-11T00:00:00Z"
+        "expiration_date_in_time": "2023-05-11T00:00:00Z"
     },
     "registrant": {
         "id": "ya88-irnic",

--- a/testdata/noterror/xn--p1ai_xn--j1ay.xn--p1ai.json
+++ b/testdata/noterror/xn--p1ai_xn--j1ay.xn--p1ai.json
@@ -14,7 +14,9 @@
             "ns.cctld.ru"
         ],
         "created_date": "2009-11-25T08:15:46Z",
-        "expiration_date": "2021-11-25T08:15:46Z"
+        "created_date_parsed": "2009-11-25T08:15:46Z",
+        "expiration_date": "2021-11-25T08:15:46Z",
+        "expiration_date_parsed": "2021-11-25T08:15:46Z"
     },
     "registrar": {
         "name": "NETHOUSE-RF"

--- a/testdata/noterror/xn--p1ai_xn--j1ay.xn--p1ai.json
+++ b/testdata/noterror/xn--p1ai_xn--j1ay.xn--p1ai.json
@@ -14,9 +14,9 @@
             "ns.cctld.ru"
         ],
         "created_date": "2009-11-25T08:15:46Z",
-        "created_date_parsed": "2009-11-25T08:15:46Z",
+        "created_date_in_time": "2009-11-25T08:15:46Z",
         "expiration_date": "2021-11-25T08:15:46Z",
-        "expiration_date_parsed": "2021-11-25T08:15:46Z"
+        "expiration_date_in_time": "2021-11-25T08:15:46Z"
     },
     "registrar": {
         "name": "NETHOUSE-RF"

--- a/testdata/noterror/xxx_google.xxx.json
+++ b/testdata/noterror/xxx_google.xxx.json
@@ -17,8 +17,11 @@
             "ns4.googledomains.com"
         ],
         "created_date": "2011-12-01T21:25:32Z",
+        "created_date_parsed": "2011-12-01T21:25:32Z",
         "updated_date": "2018-10-30T09:36:37Z",
-        "expiration_date": "2019-12-01T21:25:32Z"
+        "updated_date_parsed": "2018-10-30T09:36:37Z",
+        "expiration_date": "2019-12-01T21:25:32Z",
+        "expiration_date_parsed": "2019-12-01T21:25:32Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/xxx_google.xxx.json
+++ b/testdata/noterror/xxx_google.xxx.json
@@ -17,11 +17,11 @@
             "ns4.googledomains.com"
         ],
         "created_date": "2011-12-01T21:25:32Z",
-        "created_date_parsed": "2011-12-01T21:25:32Z",
+        "created_date_in_time": "2011-12-01T21:25:32Z",
         "updated_date": "2018-10-30T09:36:37Z",
-        "updated_date_parsed": "2018-10-30T09:36:37Z",
+        "updated_date_in_time": "2018-10-30T09:36:37Z",
         "expiration_date": "2019-12-01T21:25:32Z",
-        "expiration_date_parsed": "2019-12-01T21:25:32Z"
+        "expiration_date_in_time": "2019-12-01T21:25:32Z"
     },
     "registrar": {
         "id": "292",

--- a/testdata/noterror/xxx_porn.xxx.json
+++ b/testdata/noterror/xxx_porn.xxx.json
@@ -16,11 +16,11 @@
             "ns4.eurodns.com"
         ],
         "created_date": "2013-05-16T22:38:13Z",
-        "created_date_parsed": "2013-05-16T22:38:13Z",
+        "created_date_in_time": "2013-05-16T22:38:13Z",
         "updated_date": "2019-10-04T20:56:58Z",
-        "updated_date_parsed": "2019-10-04T20:56:58Z",
+        "updated_date_in_time": "2019-10-04T20:56:58Z",
         "expiration_date": "2021-05-16T22:38:13Z",
-        "expiration_date_parsed": "2021-05-16T22:38:13Z"
+        "expiration_date_in_time": "2021-05-16T22:38:13Z"
     },
     "registrar": {
         "id": "1052",

--- a/testdata/noterror/xxx_porn.xxx.json
+++ b/testdata/noterror/xxx_porn.xxx.json
@@ -16,8 +16,11 @@
             "ns4.eurodns.com"
         ],
         "created_date": "2013-05-16T22:38:13Z",
+        "created_date_parsed": "2013-05-16T22:38:13Z",
         "updated_date": "2019-10-04T20:56:58Z",
-        "expiration_date": "2021-05-16T22:38:13Z"
+        "updated_date_parsed": "2019-10-04T20:56:58Z",
+        "expiration_date": "2021-05-16T22:38:13Z",
+        "expiration_date_parsed": "2021-05-16T22:38:13Z"
     },
     "registrar": {
         "id": "1052",

--- a/testdata/noterror/xyz_git.xyz.json
+++ b/testdata/noterror/xyz_git.xyz.json
@@ -15,8 +15,11 @@
         ],
         "dnssec": true,
         "created_date": "2017-01-19T02:15:20.0Z",
+        "created_date_parsed": "2017-01-19T02:15:20Z",
         "updated_date": "2017-01-19T02:15:20.0Z",
-        "expiration_date": "2020-01-19T23:59:59.0Z"
+        "updated_date_parsed": "2017-01-19T02:15:20Z",
+        "expiration_date": "2020-01-19T23:59:59.0Z",
+        "expiration_date_parsed": "2020-01-19T23:59:59Z"
     },
     "registrar": {
         "id": "1556",

--- a/testdata/noterror/xyz_git.xyz.json
+++ b/testdata/noterror/xyz_git.xyz.json
@@ -15,11 +15,11 @@
         ],
         "dnssec": true,
         "created_date": "2017-01-19T02:15:20.0Z",
-        "created_date_parsed": "2017-01-19T02:15:20Z",
+        "created_date_in_time": "2017-01-19T02:15:20Z",
         "updated_date": "2017-01-19T02:15:20.0Z",
-        "updated_date_parsed": "2017-01-19T02:15:20Z",
+        "updated_date_in_time": "2017-01-19T02:15:20Z",
         "expiration_date": "2020-01-19T23:59:59.0Z",
-        "expiration_date_parsed": "2020-01-19T23:59:59Z"
+        "expiration_date_in_time": "2020-01-19T23:59:59Z"
     },
     "registrar": {
         "id": "1556",

--- a/testdata/noterror/yt_git.yt.json
+++ b/testdata/noterror/yt_git.yt.json
@@ -13,8 +13,11 @@
             "ns2.random.sh"
         ],
         "created_date": "2015-02-23T09:43:27Z",
+        "created_date_parsed": "2015-02-23T09:43:27Z",
         "updated_date": "2019-01-23T08:01:40Z",
-        "expiration_date": "2020-02-23T09:43:27Z"
+        "updated_date_parsed": "2019-01-23T08:01:40Z",
+        "expiration_date": "2020-02-23T09:43:27Z",
+        "expiration_date_parsed": "2020-02-23T09:43:27Z"
     },
     "registrar": {
         "name": "GANDI",

--- a/testdata/noterror/yt_git.yt.json
+++ b/testdata/noterror/yt_git.yt.json
@@ -13,11 +13,11 @@
             "ns2.random.sh"
         ],
         "created_date": "2015-02-23T09:43:27Z",
-        "created_date_parsed": "2015-02-23T09:43:27Z",
+        "created_date_in_time": "2015-02-23T09:43:27Z",
         "updated_date": "2019-01-23T08:01:40Z",
-        "updated_date_parsed": "2019-01-23T08:01:40Z",
+        "updated_date_in_time": "2019-01-23T08:01:40Z",
         "expiration_date": "2020-02-23T09:43:27Z",
-        "expiration_date_parsed": "2020-02-23T09:43:27Z"
+        "expiration_date_in_time": "2020-02-23T09:43:27Z"
     },
     "registrar": {
         "name": "GANDI",

--- a/testdata/noterror/yt_google.yt.json
+++ b/testdata/noterror/yt_google.yt.json
@@ -12,8 +12,11 @@
             "ns3.markmonitor.com"
         ],
         "created_date": "2011-12-06T09:03:45Z",
+        "created_date_parsed": "2011-12-06T09:03:45Z",
         "updated_date": "2019-01-14T10:32:17Z",
-        "expiration_date": "2020-02-15T19:07:10Z"
+        "updated_date_parsed": "2019-01-14T10:32:17Z",
+        "expiration_date": "2020-02-15T19:07:10Z",
+        "expiration_date_parsed": "2020-02-15T19:07:10Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/testdata/noterror/yt_google.yt.json
+++ b/testdata/noterror/yt_google.yt.json
@@ -12,11 +12,11 @@
             "ns3.markmonitor.com"
         ],
         "created_date": "2011-12-06T09:03:45Z",
-        "created_date_parsed": "2011-12-06T09:03:45Z",
+        "created_date_in_time": "2011-12-06T09:03:45Z",
         "updated_date": "2019-01-14T10:32:17Z",
-        "updated_date_parsed": "2019-01-14T10:32:17Z",
+        "updated_date_in_time": "2019-01-14T10:32:17Z",
         "expiration_date": "2020-02-15T19:07:10Z",
-        "expiration_date_parsed": "2020-02-15T19:07:10Z"
+        "expiration_date_in_time": "2020-02-15T19:07:10Z"
     },
     "registrar": {
         "name": "MARKMONITOR Inc.",

--- a/util.go
+++ b/util.go
@@ -20,8 +20,11 @@
 package whoisparser
 
 import (
+	"errors"
+	"fmt"
 	"sort"
 	"strings"
+	"time"
 )
 
 // isDNSSecEnabled returns if domain dnssec is enabled
@@ -108,4 +111,60 @@ func keys(m map[string]string) []string {
 	sort.Strings(r)
 
 	return r
+}
+
+func parseDateString(dateString string) (time.Time, error) {
+	formats := [...]string{
+		"2006-01-02T15:04:05Z",
+		"2006-01-02",
+		"2006-01-02 15:04:05",
+		"2006. 01. 02.",
+		"02-Jan-2006",
+		"02/01/2006 15:04:05",
+		"02.01.2006",
+		"02-01-2006",
+		"02.01.2006 15:04:05",
+		"02.1.2006 15:04:05",
+		"2.1.2006 15:04:05",
+		"2006-01-02 15:04:05-07",
+		"02-Jan-2006 15:04:05",
+		"January _2 2006",
+		"02/01/2006",
+		"01/02/2006",
+		"2006-01-02 15:04:05 MST",
+		"2006-Jan-02",
+		"2006-Jan-02.",
+		"2006-01-02 15:04:05 (MST+3)",
+		time.ANSIC,
+		time.UnixDate,
+		time.RubyDate,
+		time.RFC822,
+		time.RFC822Z,
+		time.RFC850,
+		time.RFC1123,
+		time.RFC1123Z,
+		time.RFC3339,
+		time.RFC3339Nano,
+		time.Stamp,
+		time.StampMilli,
+		time.StampMicro,
+		time.StampNano,
+	}
+
+	for _, format := range formats {
+		result, err := time.Parse(format, dateString)
+		if err != nil {
+			var parserError *time.ParseError
+			if errors.As(err, &parserError) {
+				// if it's a parser error try the next format
+				continue
+			} else {
+				return time.Now(), err
+			}
+		} else {
+			return result, nil
+		}
+	}
+
+	return time.Now(), fmt.Errorf("could not parse %s as a date", dateString)
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2021 Li Kexian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Go module for domain whois information parsing
+ * https://www.likexian.com/
+ */
+package whoisparser
+
+import "testing"
+
+// https://github.com/golang/go/wiki/TableDrivenTests
+func TestParseDateString(t *testing.T) {
+	t.Parallel() // marks TLog as capable of running in parallel with other tests
+	tests := []struct {
+		date string
+	}{
+		{"09-Mar-2023"},
+		{"31-Jul-2022"},
+		{"2022-12-12T11:01:02Z"},
+		{"2022-12-03"},
+		{"2022. 12. 01."},
+		{"2022-12-12 11:40:12"},
+		{"28/06/2022 23:59:59"},
+		{"24.10.2022"},
+		{"2022-06-29 14:08:21+03"},
+		{"31.8.2025 00:00:00"},
+		{"01-10-2025"},
+		{"20-Apr-2023 03:28:40"},
+		{"2022-12-08 14:00:00 CLST"},
+		{"December  2 2022"},
+		{"02/28/2025"},
+		{"April 10 2023"},
+		{"2025-Dec-11"},
+		{"2025-Dec-11."},
+		{"2024-06-05 00:00:00 (UTC+8)"},
+	}
+
+	for _, tt := range tests {
+		tt := tt // NOTE: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		t.Run(tt.date, func(t *testing.T) {
+			t.Parallel() // marks each test case as capable of running in parallel with each other
+			_, err := parseDateString(tt.date)
+			if err != nil {
+				t.Fatalf("%s should not error out. error: %v", tt.date, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for parsing whois dates as a `time.Time`. I added new fields to the struct to keep the package backwards compatible. I also added some test dates I stumbled across when querying multiple whois servers during testing.