### PR TITLE
When name cannot equal "name"

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -257,6 +257,10 @@ func searchDomain(text string) (name, extension string) {
 			extension = ""
 		}
 	}
+	
+	if name == "name" {
+		name = ""
+	}
 
 	if name != "" {
 		name = strings.ToLower(name)


### PR DESCRIPTION
Because of the regexp the `name` variable equals "name".
I have this issue with the domain `ch.tv`.  I expect to get the DomainReserved error, but because of this bug, I get an empty result.