### PR TITLE
Fixes #56 and #57

### DIFF
--- a/error.go
+++ b/error.go
@@ -80,9 +80,10 @@ func isNotFoundDomain(data string) bool {
 	return containsIn(strings.ToLower(data), notFoundKeys)
 }
 
+var reBlank = regexp.MustCompile(`\s+`)
+
 // isExtNotFoundDomain returns if domain is not found by extension
 func isExtNotFoundDomain(data, extension string) bool {
-	reBlank := regexp.MustCompile(`\s+`)
 	data = reBlank.ReplaceAllString(data, " ")
 
 	switch extension {
@@ -112,6 +113,10 @@ func isExtNotFoundDomain(data, extension string) bool {
 		}
 	case "love":
 		if strings.Contains(data, "is available") {
+			return true
+		}
+	case "se":
+		if strings.Contains(data, "not found") {
 			return true
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -240,18 +240,19 @@ func parseContact(contact *Contact, name, value string) {
 	}
 }
 
+var searchDomainRx1 = regexp.MustCompile(`(?i)\[?domain\:?(\s*\_?name)?\]?[\s\.]*\:?\s*([^\s\,\;\(\)]+)\.([^\s\,\;\(\)\.]{2,})`)
+var searchDomainRx2 = regexp.MustCompile(`(?i)\[?domain\:?(\s*\_?name)?\]?[\s\.]*\:?\s*([^\s\,\;\(\)\.]{2,})\n`)
+
 // searchDomain finds domain name and extension from whois information
 func searchDomain(text string) (name, extension string) {
-	r := regexp.MustCompile(`(?i)\[?domain\:?(\s*\_?name)?\]?[\s\.]*\:?\s*([^\s\,\;\(\)]+)\.([^\s\,\;\(\)\.]{2,})`)
-	m := r.FindStringSubmatch(text)
+	m := searchDomainRx1.FindStringSubmatch(text)
 	if len(m) > 0 {
-		name = strings.TrimSpace(m[2])
-		extension = strings.TrimSpace(m[3])
+		name = strings.TrimPrefix(strings.TrimSpace(m[2]), "\"")
+		extension = strings.TrimSuffix(strings.TrimSpace(m[3]), "\"")
 	}
 
 	if name == "" {
-		r := regexp.MustCompile(`(?i)\[?domain\:?(\s*\_?name)?\]?[\s\.]*\:?\s*([^\s\,\;\(\)\.]{2,})\n`)
-		m := r.FindStringSubmatch(text)
+		m := searchDomainRx2.FindStringSubmatch(text)
 		if len(m) > 0 {
 			name = strings.TrimSpace(m[2])
 			extension = ""

--- a/parser_test.go
+++ b/parser_test.go
@@ -112,7 +112,7 @@ func TestParse(t *testing.T) {
 		if !assert.IsContains([]string{"", "aq", "br", "ch", "de", "edu", "eu", "fr", "gov", "hk",
 			"hm", "int", "it", "jp", "kr", "kz", "mo", "nl", "nz", "pl", "pm", "re", "ro", "ru", "su", "tf", "ee",
 			"tk", "travel", "tv", "tw", "uk", "wf", "yt", "ir", "fi", "rs", "dk", "by", "ua",
-			"xn--mgba3a4f16a", "xn--p1ai"}, extension) {
+			"xn--mgba3a4f16a", "xn--p1ai", "se"}, extension) {
 			assert.NotZero(t, whoisInfo.Domain.ID)
 		}
 
@@ -132,7 +132,7 @@ func TestParse(t *testing.T) {
 			"co", "cymru", "de", "edu", "eu", "fr", "gov", "hk", "hm", "in", "int", "it", "jp", "kr",
 			"la", "london", "me", "mo", "museum", "name", "nl", "nz", "pm", "re", "ro", "ru", "sh",
 			"kz", "su", "tel", "ee", "tf", "tk", "travel", "tw", "uk", "us", "wales", "wf", "xxx",
-			"yt", "ir", "fi", "rs", "dk", "by", "ua", "xn--mgba3a4f16a", "xn--fiqs8s", "xn--p1ai"}, extension) {
+			"yt", "ir", "fi", "rs", "dk", "by", "ua", "xn--mgba3a4f16a", "xn--fiqs8s", "xn--p1ai", "se"}, extension) {
 			assert.NotZero(t, whoisInfo.Domain.WhoisServer)
 		}
 
@@ -161,7 +161,7 @@ func TestParse(t *testing.T) {
 		if !assert.IsContains([]string{"", "ai", "aq", "au", "br", "ca", "ch", "cn", "cx", "de",
 			"edu", "eu", "fr", "gov", "gs", "hk", "hm", "int", "it", "jp", "kr", "kz", "la", "mo", "nl",
 			"nz", "pl", "pm", "re", "ro", "ru", "su", "tf", "tk", "tw", "uk", "wf", "yt", "ir", "fi", "rs",
-			"ee", "dk", "by", "ua", "xn--mgba3a4f16a", "xn--fiqs8s", "xn--p1ai"}, extension) {
+			"ee", "dk", "by", "ua", "xn--mgba3a4f16a", "xn--fiqs8s", "xn--p1ai", "se"}, extension) {
 			assert.NotZero(t, whoisInfo.Registrar.ID)
 		}
 
@@ -173,7 +173,7 @@ func TestParse(t *testing.T) {
 		if !assert.IsContains([]string{"", "aero", "ai", "aq", "asia", "au", "br", "ch", "cn", "de",
 			"edu", "gov", "hk", "hm", "int", "jp", "kr", "kz", "la", "london", "love", "mo",
 			"museum", "name", "nl", "nz", "pl", "ru", "su", "tk", "top", "ir", "fi", "rs", "dk", "by", "ua",
-			"xn--mgba3a4f16a", "xn--fiqs8s", "xn--p1ai"}, extension) {
+			"xn--mgba3a4f16a", "xn--fiqs8s", "xn--p1ai", "se"}, extension) {
 			assert.NotZero(t, whoisInfo.Registrar.ReferralURL)
 		}
 

--- a/prepare.go
+++ b/prepare.go
@@ -329,6 +329,8 @@ func prepareMO(text string) string {
 	return result
 }
 
+var prepareHKEmailRx = regexp.MustCompile(`Email\:\s+([^\s]+)(\s+Hotline\:(.*))?`)
+
 // prepareHK do prepare the .hk domain
 func prepareHK(text string) string {
 	tokens := map[string]string{
@@ -364,8 +366,7 @@ func prepareHK(text string) string {
 			}
 			addressToken = field == "Address"
 			if field == "Registrar Contact Information" {
-				re := regexp.MustCompile(`Email\:\s+([^\s]+)(\s+Hotline\:(.*))?`)
-				m := re.FindStringSubmatch(vs[1])
+				m := prepareHKEmailRx.FindStringSubmatch(vs[1])
 				if len(m) == 4 {
 					v = ""
 					if m[1] != "" {
@@ -402,6 +403,8 @@ func prepareHK(text string) string {
 
 	return result
 }
+
+var prepareTWEmailRx = regexp.MustCompile(`(.*)\s+([^\s]+@[^\s]+)`)
 
 // prepareTW do prepare the .tw domain
 func prepareTW(text string) string { //nolint:cyclop
@@ -489,8 +492,7 @@ func prepareTW(text string) string { //nolint:cyclop
 				}
 				if strings.Contains(indexName, ",") {
 					ins := strings.Split(indexName, ",")
-					re := regexp.MustCompile(`(.*)\s+([^\s]+@[^\s]+)`)
-					m := re.FindStringSubmatch(v)
+					m := prepareTWEmailRx.FindStringSubmatch(v)
 					if len(m) == 3 {
 						result += fmt.Sprintf("\n%s %s: %s", tokenName, ins[0], strings.TrimSpace(m[1]))
 						result += fmt.Sprintf("\n%s %s: %s", tokenName, ins[1], strings.TrimSpace(m[2]))
@@ -683,10 +685,11 @@ func prepareRU(text string) string {
 	return result
 }
 
+var prepareJPreplacerRx = regexp.MustCompile(`\n\[(.+?)\][\ ]*(.+?)?`)
+
 // prepareJP do prepare the .jp domain
 func prepareJP(text string) string {
-	replacer := regexp.MustCompile(`\n\[(.+?)\][\ ]*(.+?)?`)
-	text = replacer.ReplaceAllString(text, "\n$1: $2")
+	text = prepareJPreplacerRx.ReplaceAllString(text, "\n$1: $2")
 
 	adminToken := "Contact Information"
 	addressToken := "Postal Address"

--- a/testdata/noterror/README.md
+++ b/testdata/noterror/README.md
@@ -151,6 +151,7 @@ If there is any problem, please feel free to open a new issue.
 | .ru | [yandex.ru](ru_yandex.ru) | [yandex.ru](ru_yandex.ru.json) | √ |
 | .scot | [gov.scot](scot_gov.scot) | [gov.scot](scot_gov.scot.json) | √ |
 | .scot | [yes.scot](scot_yes.scot) | [yes.scot](scot_yes.scot.json) | √ |
+| .se | [google.se](se_google.se) | [google.se](se_google.se.json) | √ |
 | .sexy | [google.sexy](sexy_google.sexy) | [google.sexy](sexy_google.sexy.json) | √ |
 | .sexy | [line.sexy](sexy_line.sexy) | [line.sexy](sexy_line.sexy.json) | √ |
 | .sh | [git.sh](sh_git.sh) | [git.sh](sh_git.sh.json) | √ |

--- a/testdata/noterror/se_google.se
+++ b/testdata/noterror/se_google.se
@@ -1,0 +1,32 @@
+# Copyright (c) 1997- The Swedish Internet Foundation.
+# All rights reserved.
+# The information obtained through searches, or otherwise, is protected
+# by the Swedish Copyright Act (1960:729) and international conventions.
+# It is also subject to database protection according to the Swedish
+# Copyright Act.
+# Any use of this material to target advertising or
+# similar activities is forbidden and will be prosecuted.
+# If any of the information below is transferred to a third
+# party, it must be done in its entirety. This server must
+# not be used as a backend for a search engine.
+# Result of search for registered domain names under
+# the .se top level domain.
+# This whois printout is printed with UTF-8 encoding.
+#
+state:            active
+domain:           google.se
+holder:           mmr8008-171440
+created:          2003-08-27
+modified:         2022-09-01
+expires:          2023-10-20
+transferred:      2009-03-06
+nserver:          ns1.google.com
+nserver:          ns2.google.com
+nserver:          ns3.google.com
+nserver:          ns4.google.com
+dnssec:           unsigned delegation
+registry-lock:    locked
+status:           serverUpdateProhibited
+status:           serverDeleteProhibited
+status:           serverTransferProhibited
+registrar:        MarkMonitor Inc

--- a/testdata/noterror/se_google.se.json
+++ b/testdata/noterror/se_google.se.json
@@ -1,0 +1,32 @@
+{
+    "domain": {
+        "domain": "google.se",
+        "punycode": "google.se",
+        "name": "google",
+        "extension": "se",
+        "status": [
+            "active",
+            "serverupdateprohibited",
+            "serverdeleteprohibited",
+            "servertransferprohibited"
+        ],
+        "name_servers": [
+            "ns1.google.com",
+            "ns2.google.com",
+            "ns3.google.com",
+            "ns4.google.com"
+        ],
+        "created_date": "2003-08-27",
+        "created_date_in_time": "2003-08-27T00:00:00Z",
+        "updated_date": "2022-09-01",
+        "updated_date_in_time": "2022-09-01T00:00:00Z",
+        "expiration_date": "2023-10-20",
+        "expiration_date_in_time": "2023-10-20T00:00:00Z"
+    },
+    "registrar": {
+        "name": "MarkMonitor Inc"
+    },
+    "registrant": {
+        "organization": "mmr8008-171440"
+    }
+}

--- a/testdata/notfound/se_likexian-have-no-money-to-register.se
+++ b/testdata/notfound/se_likexian-have-no-money-to-register.se
@@ -1,0 +1,16 @@
+# Copyright (c) 1997- The Swedish Internet Foundation.
+# All rights reserved.
+# The information obtained through searches, or otherwise, is protected
+# by the Swedish Copyright Act (1960:729) and international conventions.
+# It is also subject to database protection according to the Swedish
+# Copyright Act.
+# Any use of this material to target advertising or
+# similar activities is forbidden and will be prosecuted.
+# If any of the information below is transferred to a third
+# party, it must be done in its entirety. This server must
+# not be used as a backend for a search engine.
+# Result of search for registered domain names under
+# the .se top level domain.
+# This whois printout is printed with UTF-8 encoding.
+#
+domain "likexian-have-no-money-to-register.se" not found.


### PR DESCRIPTION
Adds support for the .se (Sweden) TLD.
Precompiles all regular expressions - improves performance and reduces GC pressure.
Also ensures that they all compile correctly. Not an issue for this repo since it has full test coverage, but good practice.