### PR TITLE
not delegated status fixed

### DIFF
--- a/util.go
+++ b/util.go
@@ -73,6 +73,9 @@ func fixDomainStatus(status []string) []string {
 	for k, v := range status {
 		names := strings.Split(strings.TrimSpace(v), " ")
 		status[k] = strings.ToLower(names[0])
+		if status[k] == "not" && len(names) > 1 && strings.ToLower(names[1]) == "delegated" {
+			status[k] = "not delegated"
+		}
 	}
 
 	return status


### PR DESCRIPTION
Hello, I found an issue with parsing domain status for whois data like that:

domain:        [RAGULI.RU](https://whois7.ru/RAGULI.RU)
state:         REGISTERED, NOT DELEGATED, VERIFIED
person:        Private Person
registrar:     REGRU-RU
admin-contact: [http://www.reg.ru/whois/admin_contact](https://www.reg.ru/whois/admin_contact?dname=raguli.ru)
created:       2023-06-30T15:01:10Z
paid-till:     2024-06-30T15:01:10Z
free-date:     2024-07-31
source:        TCI

"NOT DELEGATED" status resulting parses as "not".

Thank you for your project!