### PR TITLE
(bug-fix): properly parse .dk domains

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -153,6 +153,8 @@ func Parse(text string) (whoisInfo WhoisInfo, err error) { //nolint:cyclop
 			if !strings.Contains(name, " ") {
 				if name == "registrar" {
 					name += " name"
+				} else if domain.Extension == "dk" {
+					name = "registrant " + name
 				} else {
 					name += " organization"
 				}

--- a/parser_test.go
+++ b/parser_test.go
@@ -122,7 +122,7 @@ func TestParse(t *testing.T) {
 		}
 
 		if assert.IsContains([]string{"aftermarket.pl", "nazwa.pl", "git.nl", "git.wf", "by",
-			"switch.ch", "git.xyz", "emilstahl.dk", "nic.nu", "xn--fl-fka.se"}, domain) {
+			"switch.ch", "git.xyz", "emilstahl.dk", "folketinget.dk", "nic.nu", "xn--fl-fka.se"}, domain) {
 			assert.True(t, whoisInfo.Domain.DNSSec)
 		} else {
 			assert.False(t, whoisInfo.Domain.DNSSec)

--- a/rule.go
+++ b/rule.go
@@ -154,6 +154,7 @@ var (
 		"registrant zip code":                    "registrant_postal_code",
 		"registrant postal code":                 "registrant_postal_code",
 		"registrant contact postal code":         "registrant_postal_code",
+		"registrant postalcode":                  "registrant_postal_code",
 		"registrant country":                     "registrant_country",
 		"registrant country economy":             "registrant_country",
 		"registrant contact country":             "registrant_country",
@@ -183,5 +184,6 @@ var (
 		"registrant contact email":               "registrant_email",
 		"registrant contact e mail":              "registrant_email",
 		"registrant abuse contact email":         "registrant_email",
+		"registrant attention":                   "registrant_email",
 	}
 )

--- a/testdata/noterror/README.md
+++ b/testdata/noterror/README.md
@@ -62,7 +62,9 @@ If there is any problem, please feel free to open a new issue.
 | .de | [git.de](de_git.de) | [git.de](de_git.de.json) | √ |
 | .de | [google.de](de_google.de) | [google.de](de_google.de.json) | √ |
 | .dk | [emilstahl.dk](dk_emilstahl.dk) | [emilstahl.dk](dk_emilstahl.dk.json) | √ |
+| .dk | [folketinget.dk](dk_folketinget.dk) | [folketinget.dk](dk_folketinget.dk.json) | √ |
 | .dk | [google.dk](dk_google.dk) | [google.dk](dk_google.dk.json) | √ |
+| .dk | [politikken.dk](dk_politikken.dk) | [politikken.dk](dk_politikken.dk.json) | √ |
 | .edu | [cornell.edu](edu_cornell.edu) | [cornell.edu](edu_cornell.edu.json) | √ |
 | .edu | [rutgers.edu](edu_rutgers.edu) | [rutgers.edu](edu_rutgers.edu.json) | √ |
 | .edu | [snai.edu](edu_snai.edu) | [snai.edu](edu_snai.edu.json) | √ |

--- a/testdata/noterror/dk_folketinget.dk
+++ b/testdata/noterror/dk_folketinget.dk
@@ -1,0 +1,38 @@
+# Hello 1.1.1.1. Your session has been logged.
+#
+# Copyright (c) 2002 - 2024 by Punktum dk A/S
+#
+# Version: 5.2.0
+#
+# The data in the DK Whois database is provided by Punktum dk A/S
+# for information purposes only, and to assist persons in obtaining
+# information about or related to a domain name registration record.
+# We do not guarantee its accuracy. We will reserve the right to remove
+# access for entities abusing the data, without notice.
+#
+# Any use of this material to target advertising or similar activities
+# are explicitly forbidden and will be prosecuted. Punktum dk A/S
+# requests to be notified of any such activities or suspicions thereof.
+
+Domain:               folketinget.dk
+DNS:                  folketinget.dk
+Registered:           1996-05-23
+Expires:              2024-06-30
+Registration period:  2 years
+VID:                  no
+DNSSEC:               Signed delegation
+Status:               Active
+
+Registrant
+Handle:               ***N/A***
+Name:                 Folketinget
+Attention:            John Skovgaard Sørensen
+Address:              Christiansborg Slot 1
+Postalcode:           1218
+City:                 København K
+Country:              DK
+Phone:                +4533375500
+
+Nameservers
+Hostname:             maleah.ns.cloudflare.com
+Hostname:             yichun.ns.cloudflare.com

--- a/testdata/noterror/dk_folketinget.dk.json
+++ b/testdata/noterror/dk_folketinget.dk.json
@@ -1,0 +1,29 @@
+{
+    "domain": {
+        "domain": "folketinget.dk",
+        "punycode": "folketinget.dk",
+        "name": "folketinget",
+        "extension": "dk",
+        "status": [
+            "active"
+        ],
+        "name_servers": [
+            "maleah.ns.cloudflare.com",
+            "yichun.ns.cloudflare.com"
+        ],
+        "dnssec": true,
+        "created_date": "1996-05-23",
+        "created_date_in_time": "1996-05-23T00:00:00Z",
+        "expiration_date": "2024-06-30",
+        "expiration_date_in_time": "2024-06-30T00:00:00Z"
+    },
+    "registrant": {
+        "name": "Folketinget",
+        "street": "Christiansborg Slot 1",
+        "city": "København K",
+        "postal_code": "1218",
+        "country": "DK",
+        "phone": "+4533375500",
+        "email": "john skovgaard sørensen"
+    }
+}

--- a/testdata/noterror/dk_folketinget.dk.pre
+++ b/testdata/noterror/dk_folketinget.dk.pre
@@ -1,0 +1,37 @@
+# Hello 1.1.1.1. Your session has been logged.
+#
+# Copyright (c) 2002 - 2024 by Punktum dk A/S
+#
+# Version: 5.2.0
+#
+# The data in the DK Whois database is provided by Punktum dk A/S
+# for information purposes only, and to assist persons in obtaining
+# information about or related to a domain name registration record.
+# We do not guarantee its accuracy. We will reserve the right to remove
+# access for entities abusing the data, without notice.
+#
+# Any use of this material to target advertising or similar activities
+# are explicitly forbidden and will be prosecuted. Punktum dk A/S
+# requests to be notified of any such activities or suspicions thereof.
+
+Domain:               folketinget.dk
+Registered:           1996-05-23
+Expires:              2024-06-30
+Registration period:  2 years
+VID:                  no
+DNSSEC:               Signed delegation
+Status:               Active
+
+Registrant
+Handle:               ***N/A***
+Name:                 Folketinget
+Attention:            John Skovgaard Sørensen
+Address:              Christiansborg Slot 1
+Postalcode:           1218
+City:                 København K
+Country:              DK
+Phone:                +4533375500
+
+Nameservers
+Hostname:             maleah.ns.cloudflare.com
+Hostname:             yichun.ns.cloudflare.com

--- a/testdata/noterror/dk_politikken.dk
+++ b/testdata/noterror/dk_politikken.dk
@@ -1,0 +1,39 @@
+# Hello 1.1.1.1. Your session has been logged.
+#
+# Copyright (c) 2002 - 2024 by Punktum dk A/S
+#
+# Version: 5.2.0
+#
+# The data in the DK Whois database is provided by Punktum dk A/S
+# for information purposes only, and to assist persons in obtaining
+# information about or related to a domain name registration record.
+# We do not guarantee its accuracy. We will reserve the right to remove
+# access for entities abusing the data, without notice.
+#
+# Any use of this material to target advertising or similar activities
+# are explicitly forbidden and will be prosecuted. Punktum dk A/S
+# requests to be notified of any such activities or suspicions thereof.
+
+Domain:               politikken.dk
+DNS:                  politikken.dk
+Registered:           1997-01-31
+Expires:              2024-03-31
+Registration period:  1 year
+VID:                  no
+DNSSEC:               Unsigned delegation, DNSSEC disabled, no records
+Status:               Active
+
+Registrant
+Handle:               ***N/A***
+Name:                 JP/POLITIKENS HUS A/S
+Attention:            jens.mogensen@jppol.dk
+Address:              Mediebyen 3
+Postalcode:           8000
+City:                 Aarhus C
+Country:              DK
+
+Nameservers
+Hostname:             ns-1307.awsdns-35.org
+Hostname:             ns-155.awsdns-19.com
+Hostname:             ns-1951.awsdns-51.co.uk
+Hostname:             ns-534.awsdns-02.net

--- a/testdata/noterror/dk_politikken.dk.json
+++ b/testdata/noterror/dk_politikken.dk.json
@@ -1,0 +1,29 @@
+{
+    "domain": {
+        "domain": "politikken.dk",
+        "punycode": "politikken.dk",
+        "name": "politikken",
+        "extension": "dk",
+        "status": [
+            "active"
+        ],
+        "name_servers": [
+            "ns-1307.awsdns-35.org",
+            "ns-155.awsdns-19.com",
+            "ns-1951.awsdns-51.co.uk",
+            "ns-534.awsdns-02.net"
+        ],
+        "created_date": "1997-01-31",
+        "created_date_in_time": "1997-01-31T00:00:00Z",
+        "expiration_date": "2024-03-31",
+        "expiration_date_in_time": "2024-03-31T00:00:00Z"
+    },
+    "registrant": {
+        "name": "JP/POLITIKENS HUS A/S",
+        "street": "Mediebyen 3",
+        "city": "Aarhus C",
+        "postal_code": "8000",
+        "country": "DK",
+        "email": "jens.mogensen@jppol.dk"
+    }
+}

--- a/testdata/noterror/dk_politikken.dk.pre
+++ b/testdata/noterror/dk_politikken.dk.pre
@@ -1,0 +1,38 @@
+# Hello 1.1.1.1. Your session has been logged.
+#
+# Copyright (c) 2002 - 2024 by Punktum dk A/S
+#
+# Version: 5.2.0
+#
+# The data in the DK Whois database is provided by Punktum dk A/S
+# for information purposes only, and to assist persons in obtaining
+# information about or related to a domain name registration record.
+# We do not guarantee its accuracy. We will reserve the right to remove
+# access for entities abusing the data, without notice.
+#
+# Any use of this material to target advertising or similar activities
+# are explicitly forbidden and will be prosecuted. Punktum dk A/S
+# requests to be notified of any such activities or suspicions thereof.
+
+Domain:               politikken.dk
+Registered:           1997-01-31
+Expires:              2024-03-31
+Registration period:  1 year
+VID:                  no
+DNSSEC:               Unsigned delegation, DNSSEC disabled, no records
+Status:               Active
+
+Registrant
+Handle:               ***N/A***
+Name:                 JP/POLITIKENS HUS A/S
+Attention:            jens.mogensen@jppol.dk
+Address:              Mediebyen 3
+Postalcode:           8000
+City:                 Aarhus C
+Country:              DK
+
+Nameservers
+Hostname:             ns-1307.awsdns-35.org
+Hostname:             ns-155.awsdns-19.com
+Hostname:             ns-1951.awsdns-51.co.uk
+Hostname:             ns-534.awsdns-02.net


### PR DESCRIPTION
The examples in the repository, was some of the few domains in the entirety of Denmark, that didn't contain all the good information.
I've added folketinget.dk, which has a phone number example + names, etc. and politikken.dk, which has an email address as well.

Besides that, I've made a quick change in how the parser work, and made a special case for `.dk` domains.

If this does not live up to the code standard, then please do inform me :)