### PR TITLE
error: add another case for isLimitExceeded

### DIFF
--- a/error.go
+++ b/error.go
@@ -174,6 +174,7 @@ func isLimitExceeded(data string) bool {
 		"due to query limit controls",
 		"you have exceeded your allotted number of",
 		"maximum daily connection limit reached",
+		"maximum query rate reached",
 	}
 
 	return containsIn(strings.ToLower(data), limitExceedKeys)

--- a/error_test.go
+++ b/error_test.go
@@ -134,4 +134,7 @@ func TestAsisLimitExceeded(t *testing.T) {
 	data = `Domain Name: LIKEXIAN.COM
 	Registry Domain ID: 1665843940_DOMAIN_COM-VRSN`
 	assert.False(t, isLimitExceeded(data))
+
+	data = `%% Maximum query rate reached`
+	assert.True(t, isLimitExceeded(data))
 }


### PR DESCRIPTION
Some registrars (e.g. ".lu") will return a `Maximum query rate reached` message, which is currently not covered.