### PR TITLE
perf: domain status use original case

### DIFF
--- a/util.go
+++ b/util.go
@@ -72,8 +72,8 @@ func searchKeyName(key string) string {
 func fixDomainStatus(status []string) []string {
 	for k, v := range status {
 		names := strings.Split(strings.TrimSpace(v), " ")
-		status[k] = strings.ToLower(names[0])
-		if status[k] == "not" && len(names) > 1 && strings.ToLower(names[1]) == "delegated" {
+		status[k] = names[0]
+		if strings.ToLower(status[k]) == "not" && len(names) > 1 && strings.ToLower(names[1]) == "delegated" {
 			status[k] = "not delegated"
 		}
 	}


### PR DESCRIPTION
https://github.com/likexian/whois-parser/blob/c102b4e6c1467086e3ac8e9960f4238ea038c598/util.go#L72-L82

In the `fixDomainStatus`, all domain status is forcibly converted to lowercase to compare whether it is not delegated. I think domain status should be in the original case state. Users can convert case as they wish through strings.ToLower