### PR TITLE
fix: edge case for NL domains

### DIFF
--- a/prepare.go
+++ b/prepare.go
@@ -917,6 +917,7 @@ func prepareNL(text string) string {
 	for _, v := range strings.Split(text, "\n") {
 		v = strings.TrimSpace(v)
 		if v == "" {
+			token = ""
 			continue
 		}
 		if strings.HasSuffix(v, ":") {

--- a/testdata/noterror/README.md
+++ b/testdata/noterror/README.md
@@ -142,6 +142,7 @@ If there is any problem, please feel free to open a new issue.
 | .net | [hexonet.net](net_hexonet.net) | [hexonet.net](net_hexonet.net.json) | √ |
 | .nl | [git.nl](nl_git.nl) | [git.nl](nl_git.nl.json) | √ |
 | .nl | [google.nl](nl_google.nl) | [google.nl](nl_google.nl.json) | √ |
+| .nl | [paastest.nl](nl_paastest.nl) | [paastest.nl](nl_paastest.nl.json) | √ |
 | .nu | [google.nu](nu_google.nu) | [google.nu](nu_google.nu.json) | √ |
 | .nu | [nic.nu](nu_nic.nu) | [nic.nu](nu_nic.nu.json) | √ |
 | .nz | [gre.nz](nz_gre.nz) | [gre.nz](nz_gre.nz.json) | √ |

--- a/testdata/noterror/nl_paastest.nl
+++ b/testdata/noterror/nl_paastest.nl
@@ -1,0 +1,27 @@
+Domain name: paastest.nl
+Status:      active
+
+Registrar:
+   Abion AB
+   Kungsgatan 42
+   Molnlycke
+   411 15 Goteborg
+   Sweden
+
+DNSSEC:      no
+
+Domain nameservers:
+   hank.ns.cloudflare.com
+   lila.ns.cloudflare.com
+
+Creation Date: 2019-04-25
+
+Updated Date: 2024-05-23
+
+Record maintained by: SIDN BV
+
+As the registrant's address is not in the Netherlands, the registrant is
+obliged by the General Terms and Conditions for .nl Registrants to use
+SIDN's registered office address as a domicile address. More information
+on the use of a domicile address may be found at
+https://www.sidn.nl/en/nl-domain-name/domicile-address

--- a/testdata/noterror/nl_paastest.nl.json
+++ b/testdata/noterror/nl_paastest.nl.json
@@ -1,0 +1,23 @@
+{
+    "domain": {
+        "domain": "paastest.nl",
+        "punycode": "paastest.nl",
+        "name": "paastest",
+        "extension": "nl",
+        "status": [
+            "active"
+        ],
+        "name_servers": [
+            "hank.ns.cloudflare.com",
+            "lila.ns.cloudflare.com"
+        ],
+        "created_date": "2019-04-25",
+        "created_date_in_time": "2019-04-25T00:00:00Z",
+        "updated_date": "2024-05-23",
+        "updated_date_in_time": "2024-05-23T00:00:00Z"
+    },
+    "registrar": {
+        "name": "Abion AB",
+        "street": "Kungsgatan 42, Molnlycke, 411 15 Goteborg, Sweden"
+    }
+}


### PR DESCRIPTION
Fixes an edge case for some NL domains where the **"Abuse Contact:"** section is missing
Adds a test case for verification.

Solves #93 